### PR TITLE
UX polish batch: onboarding, settings, ghost overlay, rewrite

### DIFF
--- a/Sources/Shadowtype/AccessibilityNudge.swift
+++ b/Sources/Shadowtype/AccessibilityNudge.swift
@@ -148,7 +148,7 @@ final class AccessibilityNudgeController {
         self.panel = panel
 
         // Auto-dismiss so a stale banner doesn't linger after the user moved on.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 18) { [weak self, weak panel] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 30) { [weak self, weak panel] in
             if self?.panel === panel { self?.dismissPanel() }
         }
     }
@@ -303,7 +303,7 @@ final class SmartComposeNudgeController {
         panel.orderFrontRegardless()
         self.panel = panel
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 18) { [weak self, weak panel] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 30) { [weak self, weak panel] in
             if self?.panel === panel { self?.dismissPanel() }
         }
     }
@@ -374,6 +374,9 @@ private struct AXNudgeBanner: View {
                 HStack(spacing: 8) {
                     Button("How to enable", action: onHowTo)
                         .buttonStyle(.borderedProminent).controlSize(.small)
+                    // "Later" hides for this session only; "Don't show again" persists the dismissal.
+                    Button("Later", action: onClose)
+                        .buttonStyle(.bordered).controlSize(.small)
                     Button("Don't show again", action: onDismiss)
                         .buttonStyle(.bordered).controlSize(.small)
                 }

--- a/Sources/Shadowtype/AppDelegate.swift
+++ b/Sources/Shadowtype/AppDelegate.swift
@@ -84,6 +84,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let instructionStore = InstructionStore.shared
     private var lengthObserver: NSObjectProtocol?
     private var selectModelObserver: NSObjectProtocol?
+    private var rewriteHotkeyObserver: NSObjectProtocol?
     // FR-LM-1: the currently-loaded model, tracked so a failed live swap can fall back to it.
     private var currentModelURL: URL?
 
@@ -169,7 +170,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Auto-update: a silent launch check (gated by the "Automatically check for updates" toggle).
         // The repeating timer is set up by syncToggles (already run inside wireCoordinator above).
-        if autoCheckUpdatesEnabled {
+        // A pending MANDATORY update bypasses the toggle: the previous session saw a min_build force
+        // and the user deferred ("Later") or quit before staging — re-check immediately so the
+        // install prompt rides the start of this session, not minutes in.
+        if autoCheckUpdatesEnabled || UpdateManager.hasPendingMandatoryUpdate {
             Task { @MainActor in
                 await UpdateManager.shared.checkThenStage(channel: self.currentUpdateChannel(), manual: false)
             }
@@ -249,8 +253,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                            domain: self.contextTracker.frontmostDomainHost())
         }
         rewriteHotKey.onPress = { [weak self] in self?.rewriteController.trigger() }
-        rewriteHotKey.start(keyCode: UInt32(kVK_ANSI_K),
-                            modifiers: UInt32(cmdKey | optionKey), id: 2)
+        registerRewriteHotkey()
+        // The General pane's "Rewrite shortcut" picker posts this after writing the chord key —
+        // GlobalHotKey.start() tears down the old registration first, so a single call rebinds.
+        rewriteHotkeyObserver = NotificationCenter.default.addObserver(
+            forName: Notification.Name("shadowtypeRewriteHotkeyChanged"), object: nil, queue: .main
+        ) { [weak self] _ in self?.registerRewriteHotkey() }
         // TabSwallowTap.start() registers the active tap but it only swallows while a suggestion
         // is visible (gated on setSuggestionVisible, driven by onSuggestionVisibleChanged below).
         tabSwallow.start()
@@ -407,9 +415,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard !localAPI.isRunning else { return }
         _ = APIKeyStore.ensureAPIKey()   // create the bearer key on first enable so the UI can show it
         if localAPI.start() != nil {
+            UserDefaults.standard.removeObject(forKey: "shadowtype.localAPI.lastError")
             NotificationCenter.default.post(name: .shadowtypeLocalAPIDidChange, object: nil)
             Diag.log("localAPI: started on port \(localAPI.boundPort ?? -1)")
         } else {
+            // Surface the failure to the settings pane (toggle stays ON but nothing bound — without
+            // this the user flips the switch and the API silently never starts).
+            UserDefaults.standard.set(localAPI.lastError ?? "Could not start the local API server.",
+                                      forKey: "shadowtype.localAPI.lastError")
+            NotificationCenter.default.post(name: .shadowtypeLocalAPIDidChange, object: nil)
             Diag.log("localAPI: start failed (\(localAPI.lastError ?? "unknown"))")
         }
         refreshLocalAPIMenu()
@@ -607,7 +621,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Mark the engine busy for the WHOLE swap (download + reload) so the idle-unload timer can't tear
         // the model down mid-swap (and a pending idle-reload won't clobber it). Reset on every exit path.
         modelReloadInFlight = true
+        // Stream download progress to the Models pane (its row renders a determinate bar when the
+        // fraction is known). DownloadDelegate calls this off-main; observers render UI, so hop.
+        modelManager.onDownloadProgress = { fraction in
+            DispatchQueue.main.async {
+                var info: [String: Any] = ["id": entry.id]
+                if let fraction { info["fraction"] = fraction }
+                NotificationCenter.default.post(
+                    name: Notification.Name("shadowtypeModelDownloadProgress"), object: nil, userInfo: info)
+            }
+        }
         Task {
+            defer { self.modelManager.onDownloadProgress = nil }
             do {
                 let url = try await modelManager.ensureModel(entry)
                 // Hand the actual unload/load to the coordinator, which serializes it on the inference
@@ -640,11 +665,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 // Reset the busy flag AND post on main, matching the success path above — the catch
                 // body runs on a cooperative thread, so the off-main post would deliver to observers
                 // off-main (AppKit-touching ones would SIGTRAP).
+                let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
                 await MainActor.run {
                     self.modelReloadInFlight = false
                     NotificationCenter.default.post(
                         name: .shadowtypeModelDidChange, object: nil,
-                        userInfo: ["id": entry.id, "ok": false])
+                        userInfo: ["id": entry.id, "ok": false, "error": message])
                 }
             }
         }
@@ -683,7 +709,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard Date().timeIntervalSince(lastInputAt) >= Double(idleUnloadMinutes) * 60 else { return }
         coordinator.unloadModel()
         modelIdleUnloaded = true
-        statusItem.setModelName("idle — sleeps to save memory")
+        statusItem.setModelName("idle — wakes on your next keystroke")
         Diag.log("idle: unloaded model after \(idleUnloadMinutes) min")
     }
 
@@ -696,7 +722,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let ocrSettingObserver {
             NotificationCenter.default.removeObserver(ocrSettingObserver)
         }
-        for obs in [lengthObserver, selectModelObserver, appSettingsObserver].compactMap({ $0 }) {
+        for obs in [lengthObserver, selectModelObserver, appSettingsObserver, rewriteHotkeyObserver].compactMap({ $0 }) {
             NotificationCenter.default.removeObserver(obs)
         }
         idleTimer?.invalidate()
@@ -853,7 +879,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         menu.addItem(.separator())
-        let hide = NSMenuItem(title: "Hide this Button", action: #selector(hideBadgeButton), keyEquivalent: "")
+        let hide = NSMenuItem(title: "Hide this Button (restore in Settings → General)",
+                              action: #selector(hideBadgeButton), keyEquivalent: "")
         hide.target = self
         menu.addItem(hide)
 
@@ -939,6 +966,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NotificationCenter.default.post(name: .shadowtypeAppRulesDidChange, object: nil)
         refreshBadge()
         rescheduleReEnableTimer()
+    }
+
+    // Map the persisted chord choice (General pane picker) onto Carbon keycode+modifiers and
+    // (re)register. ⌥⌘K stays the default; alternates exist because it collides with Apple
+    // Writing Tools in some first-party apps on macOS 15+.
+    private func registerRewriteHotkey() {
+        let chord = UserDefaults.standard.string(forKey: "shadowtype.rewriteHotkeyChord") ?? "opt-cmd-k"
+        let keyCode: UInt32
+        let modifiers: UInt32
+        switch chord {
+        case "ctrl-cmd-k": keyCode = UInt32(kVK_ANSI_K); modifiers = UInt32(cmdKey | controlKey)
+        case "opt-cmd-j":  keyCode = UInt32(kVK_ANSI_J); modifiers = UInt32(cmdKey | optionKey)
+        default:           keyCode = UInt32(kVK_ANSI_K); modifiers = UInt32(cmdKey | optionKey)
+        }
+        if !rewriteHotKey.start(keyCode: keyCode, modifiers: modifiers, id: 2) {
+            // Registration failures are otherwise invisible — record for the settings pane.
+            UserDefaults.standard.set("Couldn't register the rewrite shortcut (in use by another app).",
+                                      forKey: "shadowtype.rewriteHotkey.lastError")
+            Diag.log("rewriteHotkey: registration failed for \(chord) (status \(rewriteHotKey.lastStatus))")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "shadowtype.rewriteHotkey.lastError")
+        }
     }
 
     @objc private func hideBadgeButton() {

--- a/Sources/Shadowtype/BadgeRenderer.swift
+++ b/Sources/Shadowtype/BadgeRenderer.swift
@@ -26,7 +26,11 @@ final class BadgeRenderer {
         panel = NSPanel(contentRect: NSRect(x: 0, y: 0, width: size, height: size),
                         styleMask: [.nonactivatingPanel, .borderless],
                         backing: .buffered, defer: false)
-        panel.level = .statusBar
+        // floating+1, NOT .statusBar: this panel is CLICKABLE (unlike the click-through ghost), and at
+        // .statusBar level it can sit invisible-but-clickable behind the system menu-bar icons,
+        // swallowing clicks meant for them. floating+1 keeps it above normal windows and the ghost's
+        // anchor field while staying below the system status bar layer.
+        panel.level = NSWindow.Level(rawValue: NSWindow.Level.floating.rawValue + 1)
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = true                          // a floating chip, unlike the shadowless ghost

--- a/Sources/Shadowtype/CompletionCoordinator.swift
+++ b/Sources/Shadowtype/CompletionCoordinator.swift
@@ -265,7 +265,9 @@ final class CompletionCoordinator {
     private var activePrefix: String = ""
     // Memo for applyGlueGuard: renderSuggestion runs on every streamed token snapshot, but for a fixed
     // prefix the trailing word and the suggestion's leading glue run are stable — so the language detect
-    // + two spell lookups should run once per generation, not per token. Keyed on (prefix, glue run).
+    // + two spell lookups should run once per generation, not per token. Keyed on (prefix, glue run,
+    // first 24 chars of the suggestion) — the suggestion slice disambiguates two different suggestions
+    // that share a prefix + leading-letter run (e.g. both space-leading).
     private var glueGuardMemoKey: String?
     private var glueGuardMemoResult: String?
     private var suggestionText: String = ""
@@ -570,6 +572,11 @@ final class CompletionCoordinator {
         // FR-KC-4 / disabled-app+domain gate: never suggest in a secure field or a suppressed
         // app/domain (FR-PA-1/2). AppRules default is on everywhere; nil rules == on everywhere.
         if context.isSecureField() { Diag.log("fire: skip secureField"); clearSuggestion(); return }
+        // IME composition guard: while marked (preedit) text is live — CJK composition — never fire,
+        // and clear any visible ghost (it overlaps the candidate window and an accept would splice into
+        // the composition buffer). Best-effort single AX read; hosts that don't expose AXMarkedTextRange
+        // return false and behave exactly as before (see EditContextTracker.hasMarkedText).
+        if context.hasMarkedText() { Diag.log("fire: skip markedText (IME composing)"); clearSuggestion(); return }
         if let appRules, !appRules.isEnabled(bundleId: context.frontmostBundleId,
                                              domain: context.frontmostDomainHost()) {
             Diag.log("fire: skip disabledApp/domain \(context.frontmostBundleId ?? "?")"); clearSuggestion(); return
@@ -1094,6 +1101,11 @@ final class CompletionCoordinator {
     // happened and a lazy reload is needed before the next suggestion.
     var isModelLoaded: Bool { engine.isLoaded }
 
+    // CONTRACT: exact name `isEngineLoaded` — another agent's code (rewrite/menu guards, see the
+    // engine.isLoaded gate in rewrite()) compiles against this property. Whether the inference engine
+    // is loaded and ready to generate. Alias of isModelLoaded; keep both stable.
+    var isEngineLoaded: Bool { engine.isLoaded }
+
     // MARK: - Accept (FR §M4 — Tab/word accept -> Injector)
 
     // Inject the next whole word of the live suggestion. Returns words injected (0 if none).
@@ -1128,9 +1140,12 @@ final class CompletionCoordinator {
             // rising-edge push doesn't fire here since visibility was already true).
             onCaretAtLineEndChanged?(context.caretAtLineEnd())
         }
+        // Return the REAL word count (0 allowed): a whitespace/punctuation-only accepted chunk is not a
+        // word and must not inflate the meter. Callers treat 0 as "nothing to count", never as failure
+        // (AppDelegate.applyAccept just skips the increment) — same contract as the 0-word emoji path.
         let n = WordMeter.wordCount(in: word)
         recordStyle(word)   // FR-CTX-3: learn from the accepted phrasing (gated inside).
-        return n > 0 ? n : 1
+        return n
     }
 
     // Inject the whole current line of the suggestion (up to the first newline).
@@ -1994,7 +2009,7 @@ final class CompletionCoordinator {
     //   • A trailing INCOMPLETE tag-like run during streaming (`<stro` before its `>` arrives) is
     //     dropped so it never flashes; it reappears stripped once the closing `>` streams in.
     //   • A bare `<` NOT followed by a letter/'/' (e.g. "a < b", "<3") is kept as a literal.
-    //   • `**` and backticks are removed (rare in prose autocomplete; the model uses them as markup).
+    //   • `**` is removed; backticks are removed only when UNPAIRED (balanced pairs = inline code, kept).
     static func sanitizedSuggestion(_ s: String) -> String {
         let chars = Array(s)
         var out = ""
@@ -2031,7 +2046,13 @@ final class CompletionCoordinator {
             i += 1
         }
         out = out.replacingOccurrences(of: "**", with: "")
-        out = out.replacingOccurrences(of: "`", with: "")
+        // Backticks: strip only when UNPAIRED (odd count — a stray markup tick, or the first half of a
+        // pair still streaming in). Balanced pairs are inline code the user plausibly wants verbatim
+        // ("run `make test`"); blanket-stripping mangled it to "run make test". Still idempotent: an
+        // odd count strips to zero, and an even count is left untouched.
+        if out.lazy.filter({ $0 == "`" }).count % 2 != 0 {
+            out = out.replacingOccurrences(of: "`", with: "")
+        }
         out = Self.strippingRuleRuns(out)
         // Strip detokenizer junk (U+FFFD, stray C0 controls/DEL; tab + line feed kept) so a single bad
         // scalar no longer hides the whole completion — the rest of the suggestion still shows (#1).
@@ -2219,7 +2240,10 @@ final class CompletionCoordinator {
     // (never breaks a good completion). Memoized per (prefix, glue) so the spell lookups run ~once per gen.
     private func applyGlueGuard(_ suggestion: String, prefix: String) -> String {
         let glueRun = String(suggestion.prefix(while: { $0.isLetter }))
-        let memoKey = prefix + "\u{0}" + glueRun
+        // Key on (prefix, glue run, suggestion head): prefix + glue run alone collide for two different
+        // suggestions whose leading letter run matches (e.g. any two space-leading suggestions share an
+        // empty run), so a stable slice of the suggestion itself disambiguates the memo.
+        let memoKey = prefix + "\u{0}" + glueRun + "\u{0}" + String(suggestion.prefix(24))
         let drop: String?
         if glueGuardMemoKey == memoKey {
             drop = glueGuardMemoResult

--- a/Sources/Shadowtype/EditContextTracker.swift
+++ b/Sources/Shadowtype/EditContextTracker.swift
@@ -400,6 +400,22 @@ final class EditContextTracker {
         return isSecure(element)
     }
 
+    // IME composition probe (best-effort): a non-empty "AXMarkedTextRange" on the focused element means
+    // the user is mid-composition (CJK/preedit), where an inline ghost fights the candidate UI and an
+    // accept would corrupt the composition buffer. There is no public kAX… constant for it; Cocoa text
+    // views (NSTextView / NSTextInputClient hosts) expose the attribute by this name. Known limitation:
+    // many hosts (Chromium/Electron web fields, Catalyst) don't surface marked text through AX at all —
+    // there this returns false and callers behave as today (fail-open). Single AX call, no descend.
+    func hasMarkedText() -> Bool {
+        guard let element = currentFocusedElement() else { return false }
+        var ref: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, "AXMarkedTextRange" as CFString, &ref) == .success,
+              let v = ref, CFGetTypeID(v) == AXValueGetTypeID() else { return false }
+        var range = CFRange()
+        guard AXValueGetValue(v as! AXValue, .cfRange, &range) else { return false }
+        return range.length > 0
+    }
+
     // FR-IN-2: the live focused AX element, for direct-AX text injection at accept time. nil when
     // nothing editable is focused or AX is untrusted (Injector then falls back to Unicode posting).
     // Injection into secure fields is gated upstream — the coordinator never shows, and so never

--- a/Sources/Shadowtype/EmojiCompletion.swift
+++ b/Sources/Shadowtype/EmojiCompletion.swift
@@ -171,8 +171,14 @@ final class EmojiCompletion {
 
     // The partial shortcode after the last unterminated `:`, or nil. Lowercased for matching.
     // Returns nil for an empty query (`...:`) — there's nothing to match yet.
+    // The colon must start a token: at the beginning of the prefix or preceded by whitespace.
+    // Otherwise mid-text colons misfire ("meeting at 3:smile", "ratio 1:1", "http://x:port").
     func currentQuery(prefix: String) -> String? {
         guard let colon = prefix.lastIndex(of: ":") else { return nil }
+        if colon != prefix.startIndex {
+            let before = prefix[prefix.index(before: colon)]
+            guard before.isWhitespace else { return nil }
+        }
         let after = prefix[prefix.index(after: colon)...]
         guard !after.isEmpty else { return nil }
         for ch in after where !Self.isShortcodeChar(ch) { return nil }

--- a/Sources/Shadowtype/FocusCapabilityFlickerGate.swift
+++ b/Sources/Shadowtype/FocusCapabilityFlickerGate.swift
@@ -19,8 +19,11 @@
 // on the same session still propagates after `requiredConsecutiveMisses` so real focus-loss isn't
 // perceptibly delayed.
 struct FocusCapabilityFlickerGate {
-    // Consecutive no-context reads on the same focus session before the gate releases the teardown.
-    // Two is enough to swallow the single-poll flicker without delaying real focus loss perceptibly.
+    // RELEASE THRESHOLD: the gate tears down on the Nth consecutive no-context read of the same focus
+    // session, i.e. it swallows exactly N-1 bad reads. At 2 it suppresses the single-poll flicker (the
+    // observed Catalyst failure mode) and releases on the 2nd miss. Deliberately NOT higher: each
+    // "read" is a full fire() after a typing pause, so every extra swallowed miss keeps a stale ghost
+    // over a genuinely dead field for one more pause cycle.
     static let requiredConsecutiveMisses = 2
 
     enum Decision: Equatable {

--- a/Sources/Shadowtype/GhostFontSizeStabilizer.swift
+++ b/Sources/Shadowtype/GhostFontSizeStabilizer.swift
@@ -17,14 +17,20 @@
 import CoreGraphics
 
 struct GhostFontSizeStabilizer {
+    // Plausibility floor: no readable text line is shorter than ~8pt, so a caret-height reading below
+    // it is AX noise (a collapsed/zero rect mid-relayout), not a real smaller line. Such readings pass
+    // through untouched and never lower the session minimum — otherwise one bad poll would pin every
+    // later suggestion to the font-size floor for the rest of the focus session.
+    static let minPlausibleCaretHeight: CGFloat = 8
+
     private var sessionKey: UInt64?
     private var minCaretHeight: CGFloat?
 
     // Returns the caret height to derive the ghost font size from: the running per-session minimum.
-    // Non-positive heights (empty/unusable rects) pass through untouched so a transient bad poll can't
-    // pin the session minimum to zero and force every later suggestion to the font-size floor.
+    // Implausibly small heights (non-positive / sub-8pt — empty or collapsed rects) pass through
+    // untouched so a transient bad poll can't drag the session minimum down (see floor above).
     mutating func stabilizedCaretHeight(_ caretHeight: CGFloat, focusSessionKey: UInt64) -> CGFloat {
-        guard caretHeight > 0 else { return caretHeight }
+        guard caretHeight >= Self.minPlausibleCaretHeight else { return caretHeight }
 
         if sessionKey != focusSessionKey {
             sessionKey = focusSessionKey

--- a/Sources/Shadowtype/GlobalHotKey.swift
+++ b/Sources/Shadowtype/GlobalHotKey.swift
@@ -10,6 +10,11 @@ import AppKit
 final class GlobalHotKey {
     var onPress: (() -> Void)?
 
+    // Registration status, observable by callers (Settings shows "hotkey in use by another app"
+    // when start() fails). `lastStatus` keeps the raw OSStatus of the most recent attempt.
+    var isRegistered: Bool { hotKeyRef != nil }
+    private(set) var lastStatus: OSStatus = noErr
+
     private var hotKeyRef: EventHotKeyRef?
     private var handlerRef: EventHandlerRef?
     // 'SHTY' signature + a per-instance id disambiguate our hotkeys inside the shared application event
@@ -18,12 +23,14 @@ final class GlobalHotKey {
     private var hotKeyID = EventHotKeyID(signature: 0x53485459, id: 1)
 
     // Default ⌃` (grave). keyCode/modifiers use Carbon virtual-key + modifier constants. `id` must be
-    // unique across live GlobalHotKey instances. No-op (with a diagnostic) if the handler can't install or
-    // the key is already claimed — never leaves a half-registered state that a later start() would double
-    // up on.
+    // unique across live GlobalHotKey instances. Returns false (with a diagnostic) if the handler can't
+    // install or the key is already claimed — never leaves a half-registered state that a later start()
+    // would double up on. Calling while registered re-registers: the existing hotkey + handler come
+    // down first, so callers can rebind to a new chord with a single start() call.
+    @discardableResult
     func start(keyCode: UInt32 = UInt32(kVK_ANSI_Grave), modifiers: UInt32 = UInt32(controlKey),
-               id: UInt32 = 1) {
-        guard hotKeyRef == nil else { return }
+               id: UInt32 = 1) -> Bool {
+        if hotKeyRef != nil { stop() }
         hotKeyID.id = id
 
         var spec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
@@ -45,7 +52,9 @@ final class GlobalHotKey {
             return noErr
         }, 1, &spec, selfPtr, &handler)
         guard installStatus == noErr, let handler else {
-            Diag.log("GlobalHotKey: InstallEventHandler failed (\(installStatus))"); return
+            Diag.log("GlobalHotKey: InstallEventHandler failed (\(installStatus))")
+            lastStatus = installStatus
+            return false
         }
 
         var ref: EventHotKeyRef?
@@ -53,10 +62,13 @@ final class GlobalHotKey {
         guard regStatus == noErr, let ref else {
             Diag.log("GlobalHotKey: RegisterEventHotKey failed (\(regStatus)) — key in use?")
             RemoveEventHandler(handler)   // don't leak the handler we just installed
-            return
+            lastStatus = regStatus
+            return false
         }
         handlerRef = handler
         hotKeyRef = ref
+        lastStatus = noErr
+        return true
     }
 
     func stop() {

--- a/Sources/Shadowtype/HFImportSheet.swift
+++ b/Sources/Shadowtype/HFImportSheet.swift
@@ -26,6 +26,10 @@ struct HFImportSheet: View {
     @State private var status: String = ""
     @State private var isError = false
     @State private var progress: Double? = nil
+    // The in-flight download, kept so Cancel can actually abort the transfer (cooperative
+    // cancellation propagates into ModelManager's URLSession download) instead of letting it
+    // finish + register behind the dismissed sheet.
+    @State private var downloadTask: Task<Void, Never>? = nil
 
     private enum Phase {
         case input, resolving, pickingFile, downloading, done
@@ -92,6 +96,9 @@ struct HFImportSheet: View {
         VStack(alignment: .leading, spacing: 10) {
             Text("\(siblings.count) GGUF file\(siblings.count == 1 ? "" : "s") found in this repo. Pick one to import:")
                 .font(.callout)
+            Text("Q4_K_M is the recommended balance of quality and size.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 4) {
                     ForEach(siblings, id: \.filename) { s in
@@ -149,7 +156,10 @@ struct HFImportSheet: View {
 
     private var buttonBar: some View {
         HStack {
-            Button("Cancel") { dismiss() }
+            Button("Cancel") {
+                downloadTask?.cancel()
+                dismiss()
+            }
             Spacer()
             switch phase {
             case .input, .resolving:
@@ -195,8 +205,11 @@ struct HFImportSheet: View {
                 DispatchQueue.main.async {
                     switch result {
                     case .success(let list):
-                        siblings = list
-                        selectedSibling = list.first
+                        // Smallest-first ordering + Q4_K_M default (the recommended quant) so the
+                        // happy path is "paste URL, Resolve, Import" with no scrolling.
+                        let sorted = HFResolver.sortedBySizeAscending(list)
+                        siblings = sorted
+                        selectedSibling = HFResolver.preferredImportFile(in: sorted)
                         phase = .pickingFile
                         status = ""
                     case .failure(let err):
@@ -229,7 +242,7 @@ struct HFImportSheet: View {
         status = "Downloading \(filename)…"
         progress = nil
 
-        Task {
+        downloadTask = Task {
             let manager = ModelManager()
             manager.onDownloadProgress = { p in
                 DispatchQueue.main.async { progress = p }
@@ -244,6 +257,13 @@ struct HFImportSheet: View {
                 let target = importsDir.appendingPathComponent(filename)
                 let final = try await manager.downloadAuthenticated(
                     from: downloadURL, to: target, token: usedToken)
+
+                // Cancelled while (or right after) downloading: do NOT register the import — the
+                // user dismissed the sheet. Clean up the file so a half-meant import doesn't linger.
+                if Task.isCancelled {
+                    try? FileManager.default.removeItem(at: final)
+                    return
+                }
 
                 // Approximate RAM ≈ file size for quantized GGUFs.
                 let bytes = (try? FileManager.default.attributesOfItem(atPath: final.path)[.size] as? NSNumber)?.int64Value ?? 0
@@ -264,6 +284,9 @@ struct HFImportSheet: View {
                     onImported(entry)
                     dismiss()
                 }
+            } catch is CancellationError {
+                // User hit Cancel — the sheet is already dismissing; nothing to report.
+                return
             } catch {
                 await MainActor.run {
                     phase = .input

--- a/Sources/Shadowtype/HFResolver.swift
+++ b/Sources/Shadowtype/HFResolver.swift
@@ -114,6 +114,25 @@ enum HFResolver {
         return URL(string: "https://huggingface.co/\(owner)/\(repo)/resolve/main/\(encoded)")
     }
 
+    // Picker ordering: ascending by size so the cheapest download reads first; unknown sizes sink
+    // to the bottom; filename breaks ties for a stable order. Pure + testable.
+    static func sortedBySizeAscending(_ list: [Sibling]) -> [Sibling] {
+        list.sorted { a, b in
+            switch (a.sizeBytes, b.sizeBytes) {
+            case let (x?, y?): return x != y ? x < y : a.filename < b.filename
+            case (.some, .none): return true
+            case (.none, .some): return false
+            case (.none, .none): return a.filename < b.filename
+            }
+        }
+    }
+
+    // Default pick for the import picker: a Q4_K_M quant when the repo has one (the recommended
+    // quality/size balance, matching the curated catalog), else the first file. Pure + testable.
+    static func preferredImportFile(in list: [Sibling]) -> Sibling? {
+        list.first { $0.filename.lowercased().contains("q4_k_m") } ?? list.first
+    }
+
     // Best-effort short label for a sibling row in the picker UI.
     static func displaySize(_ bytes: Int64?) -> String {
         guard let b = bytes else { return "" }

--- a/Sources/Shadowtype/Injector.swift
+++ b/Sources/Shadowtype/Injector.swift
@@ -267,11 +267,15 @@ final class Injector {
 
         // Restore the user's clipboard after the paste has been delivered. The session-tap events are
         // queued FIFO ahead of this main-thread hop, so a short delay keeps us from clobbering the
-        // pasteboard before the host reads it. Residual race: a host that reads the pasteboard later than
-        // this delay would see the restored contents — unavoidable with synthetic paste, mitigated by the
-        // delay; the changeCount guard prevents stomping a NEWER user copy. Restoring [] (nothing was
-        // saved) clears our completion text rather than stranding it on the clipboard.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+        // pasteboard before the host reads it. 350 ms (was 200): slow Electron/web hosts service the
+        // Cmd-V on their renderer loop well after the event lands, and a 200 ms restore raced them —
+        // the host then pasted the RESTORED clipboard and the accepted text was lost. Tradeoff: the
+        // longer delay widens the window where the user's clipboard briefly holds our completion text;
+        // the changeCount guard below still protects any NEWER copy they make meanwhile, and there is
+        // no general way to detect that the host actually consumed the paste. Residual race: a host
+        // that reads even later sees the restored contents — unavoidable with synthetic paste.
+        // Restoring [] (nothing was saved) clears our completion text rather than stranding it.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
             guard pb.changeCount == ourChangeCount else { return }   // user/app copied since: leave it
             Self.restorePasteboard(pb, items: savedItems)
         }

--- a/Sources/Shadowtype/LaunchAtLogin.swift
+++ b/Sources/Shadowtype/LaunchAtLogin.swift
@@ -4,15 +4,25 @@ import ServiceManagement
 enum LaunchAtLogin {
     static var isEnabled: Bool { SMAppService.mainApp.status == .enabled }
 
-    static func setEnabled(_ on: Bool) {
+    /// Human-readable description of the last setEnabled failure; nil after a success.
+    private(set) static var lastError: String?
+
+    /// Returns the SMAppService outcome so callers can surface a failure (the system can refuse —
+    /// e.g. Login Items restrictions) instead of silently leaving the toggle out of sync.
+    @discardableResult
+    static func setEnabled(_ on: Bool) -> Result<Void, Error> {
         do {
             if on {
                 try SMAppService.mainApp.register()
             } else {
                 try SMAppService.mainApp.unregister()
             }
+            lastError = nil
+            return .success(())
         } catch {
+            lastError = error.localizedDescription
             Diag.log("LaunchAtLogin.setEnabled(\(on)) failed: \(error.localizedDescription)")
+            return .failure(error)
         }
     }
 }

--- a/Sources/Shadowtype/LocalAPIServer.swift
+++ b/Sources/Shadowtype/LocalAPIServer.swift
@@ -22,6 +22,11 @@ final class LocalAPIServer {
     static let portCandidates: [Int] = [5666, 5667, 5668, 5669, 5670]
     static let maxPendingDepth: Int = 4
 
+    // Human-readable all-ports-busy reason — surfaced verbatim in Settings, so phrase it for users.
+    static var allPortsBusyMessage: String {
+        "Ports \(portCandidates.first!)\u{2013}\(portCandidates.last!) are all in use"
+    }
+
     // The path matches what the MCP bridge looks for; keep them in sync.
     static var udsPath: String {
         let dir = (NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first ?? NSHomeDirectory())
@@ -68,7 +73,9 @@ final class LocalAPIServer {
             }
         }
         guard boundPort != nil else {
-            lastError = "all TCP ports busy (\(Self.portCandidates.first!)\u{2013}\(Self.portCandidates.last!))"
+            // Leave state fully stopped: isRunning stays false, no FDs were kept, no accept sources
+            // started. Callers read `lastError` to tell the user why start() returned nil.
+            lastError = Self.allPortsBusyMessage
             return nil
         }
 
@@ -91,8 +98,9 @@ final class LocalAPIServer {
         tcpAcceptSource?.cancel(); tcpAcceptSource = nil
         udsAcceptSource?.cancel(); udsAcceptSource = nil
         if tcpFD >= 0 { close(tcpFD); tcpFD = -1 }
-        if udsFD >= 0 { close(udsFD); udsFD = -1 }
-        unlink(Self.udsPath)
+        // Only unlink the socket path if WE bound it — a server that never started (e.g. all ports
+        // busy) must not delete a live instance's UDS socket from its deinit.
+        if udsFD >= 0 { close(udsFD); udsFD = -1; unlink(Self.udsPath) }
         boundPort = nil
         NotificationCenter.default.removeObserver(self)
     }

--- a/Sources/Shadowtype/LocalAPISettingsPane.swift
+++ b/Sources/Shadowtype/LocalAPISettingsPane.swift
@@ -15,6 +15,15 @@ struct LocalAPISettingsPane: View {
     @State private var statusText: String = "Stopped"
     @State private var portText: String = "—"
     @State private var copyConfirmation: String? = nil
+    // True between flipping the toggle on and the next .shadowtypeLocalAPIDidChange — the server
+    // bind is async, so without this the pane claims "Stopped" while the server is coming up.
+    @State private var starting = false
+    // Failure reason AppDelegate persisted to UserDefaults "shadowtype.localAPI.lastError" when the
+    // server could not start (cleared on success). Shown when the toggle is on but no port is bound.
+    @State private var startError: String? = nil
+    // Key-rotation warning — separate from the transient copy-confirmation label: it must persist
+    // until the user dismisses it (or closes the pane), because stale keys break existing clients.
+    @State private var rotationWarning: String? = nil
 
     var body: some View {
         ScrollView {
@@ -33,7 +42,10 @@ struct LocalAPISettingsPane: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onAppear { refresh() }
-        .onReceive(NotificationCenter.default.publisher(for: .shadowtypeLocalAPIDidChange)) { _ in refresh() }
+        .onReceive(NotificationCenter.default.publisher(for: .shadowtypeLocalAPIDidChange)) { _ in
+            starting = false   // AppDelegate posts this even on failure; the start attempt is over
+            refresh()
+        }
     }
 
     // MARK: - Sections
@@ -56,7 +68,9 @@ struct LocalAPISettingsPane: View {
                     .font(.body.weight(.medium))
             }
             .toggleStyle(.switch)
-            .onChange(of: serverEnabled) { _, _ in
+            .onChange(of: serverEnabled) { _, newValue in
+                starting = newValue        // bind is async; show "Starting…" until DidChange lands
+                startError = nil
                 NotificationCenter.default.post(name: .shadowtypeToggleLocalAPI, object: nil)
             }
             Text("Starts on launch as long as this toggle is on. The server listens on 127.0.0.1 only — never on your local network.")
@@ -67,17 +81,34 @@ struct LocalAPISettingsPane: View {
     }
 
     @ViewBuilder private var statusSection: some View {
-        HStack(spacing: 16) {
-            Label(statusText, systemImage: "circle.fill")
-                .labelStyle(.titleAndIcon)
-                .font(.callout.weight(.medium))
-                .foregroundStyle(statusText.contains("Running") ? .green : .secondary)
-            Text("Port \(portText)")
-                .font(.callout.monospacedDigit())
-                .foregroundStyle(.secondary)
-            Spacer()
-            Button("Copy URL") { copy(serverURL, label: "URL") }
-                .disabled(portText == "—")
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 16) {
+                if starting {
+                    HStack(spacing: 6) {
+                        ProgressView().controlSize(.small)
+                        Text("Starting…")
+                            .font(.callout.weight(.medium))
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Label(statusText, systemImage: "circle.fill")
+                        .labelStyle(.titleAndIcon)
+                        .font(.callout.weight(.medium))
+                        .foregroundStyle(statusText.contains("Running") ? .green : .secondary)
+                }
+                Text("Port \(portText)")
+                    .font(.callout.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Copy URL") { copy(serverURL, label: "URL") }
+                    .disabled(portText == "—")
+            }
+            if let err = startError, !starting {
+                Label("The server failed to start: \(err)", systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
         .padding(12)
         .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 8))
@@ -103,8 +134,31 @@ struct LocalAPISettingsPane: View {
                     .disabled(apiKey.isEmpty)
                 Button("Regenerate") {
                     apiKey = APIKeyStore.regenerateAPIKey()
-                    copyConfirmation = "Rotated — existing clients will need the new key."
+                    rotationWarning = "API key rotated — every client still using the old key will be rejected until you paste the new one."
                 }
+            }
+            if let warning = rotationWarning {
+                HStack(alignment: .top, spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                    Text(warning)
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer()
+                    Button {
+                        rotationWarning = nil
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Dismiss")
+                }
+                .padding(10)
+                .background(Color.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 8))
+                .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.orange.opacity(0.30), lineWidth: 1))
             }
         }
     }
@@ -178,9 +232,15 @@ struct LocalAPISettingsPane: View {
            p > 0 {
             statusText = "Running"
             portText = String(p)
+            startError = nil
         } else {
             statusText = "Stopped"
             portText = "—"
+            // Toggle on but nothing bound → the start attempt failed. AppDelegate persists the
+            // reason to "shadowtype.localAPI.lastError" (cleared on success); surface it here.
+            startError = serverEnabled
+                ? UserDefaults.standard.string(forKey: "shadowtype.localAPI.lastError")
+                : nil
         }
     }
 

--- a/Sources/Shadowtype/ModelManager.swift
+++ b/Sources/Shadowtype/ModelManager.swift
@@ -10,6 +10,7 @@ enum ModelManagerError: LocalizedError {
     case noDownloadedFile
     case checksumMismatch(expected: String, actual: String)
     case invalidModelFile(String)
+    case insufficientDiskSpace(neededGB: Double, availableGB: Double)
 
     var errorDescription: String? {
         switch self {
@@ -25,6 +26,9 @@ enum ModelManagerError: LocalizedError {
             return "Model checksum mismatch (expected \(expected), got \(actual)). The file is corrupt or incomplete."
         case .invalidModelFile(let id):
             return "Downloaded model \(id) is not a valid GGUF file (corrupt, truncated, or not a model)."
+        case .insufficientDiskSpace(let neededGB, let availableGB):
+            return String(format: "Not enough disk space (need %.1f GB, %.1f GB available).",
+                          neededGB, availableGB)
         }
     }
 }
@@ -122,6 +126,10 @@ final class ModelManager {
         }
         try FileManager.default.createDirectory(at: modelsDirectory(),
                                                 withIntermediateDirectories: true)
+        // Disk-space preflight: fail fast with an actionable message instead of letting a multi-GB
+        // download die mid-flight (or fill the volume). Surfaces through the same error path as any
+        // other download failure (.shadowtypeModelDidChange userInfo["error"]).
+        try preflightDiskSpace(neededBytes: Int64(entry.downloadGB * 1e9))
         try await download(from: entry.url, to: destination)
 
         if let expected = entry.sha256 {
@@ -157,6 +165,26 @@ final class ModelManager {
         return actual.caseInsensitiveCompare(expected) == .orderedSame
     }
 
+    // MARK: - Disk-space preflight
+
+    /// Pure comparison, split out so it's unit-testable without touching the real volume.
+    /// Throws `.insufficientDiskSpace` with the human-facing GB figures when the download won't fit.
+    static func checkDiskSpace(neededBytes: Int64, availableBytes: Int64) throws {
+        guard availableBytes < neededBytes else { return }
+        throw ModelManagerError.insufficientDiskSpace(neededGB: Double(neededBytes) / 1e9,
+                                                      availableGB: Double(availableBytes) / 1e9)
+    }
+
+    /// Queries the models volume's `volumeAvailableCapacityForImportantUsage` and throws when the
+    /// expected download size won't fit. An unreadable capacity is treated as "unknown, proceed" —
+    /// the download itself will fail with a normal error if the disk really is full.
+    private func preflightDiskSpace(neededBytes: Int64) throws {
+        let dir = modelsDirectory()
+        guard let vals = try? dir.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey]),
+              let available = vals.volumeAvailableCapacityForImportantUsage else { return }
+        try Self.checkDiskSpace(neededBytes: neededBytes, availableBytes: available)
+    }
+
     // MARK: - Paths
 
     private func modelsDirectory() -> URL {
@@ -177,6 +205,9 @@ final class ModelManager {
 
     private func download(from url: URL, to destination: URL,
                           authorization: String? = nil) async throws {
+        // Cooperative cancellation: a caller cancelling its Task (e.g. the HF import sheet's Cancel
+        // button) must abort the transfer instead of completing + registering the import.
+        try Task.checkCancellation()
         let delegate = DownloadDelegate(onProgress: onDownloadProgress)
         let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
         defer { session.finishTasksAndInvalidate() }
@@ -201,6 +232,12 @@ final class ModelManager {
             try FileManager.default.moveItem(at: tempURL, to: destination)
         } catch let error as ModelManagerError {
             throw error
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as URLError where error.code == .cancelled {
+            // URLSession surfaces a cancelled Task as URLError(.cancelled); normalize so callers
+            // can distinguish a user cancel from a real failure.
+            throw CancellationError()
         } catch {
             // URLSession download resumes automatically from partial data on transient failures;
             // a thrown error here means the download could not complete.

--- a/Sources/Shadowtype/OnboardingWindow.swift
+++ b/Sources/Shadowtype/OnboardingWindow.swift
@@ -19,6 +19,9 @@ import SwiftUI
 
 final class OnboardingWindowController: NSObject, NSWindowDelegate {
     static let didCompleteKey = "shadowtype.didCompleteOnboarding"
+    /// Current step's raw value, written on every step change so closing the window mid-flow
+    /// resumes where the user left off on the next launch.
+    static let stepKey = "shadowtype.onboardingStep"
 
     private var window: NSWindow?
 
@@ -60,10 +63,28 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
 
     func windowWillClose(_ notification: Notification) {
         AppActivation.shared.windowClosed()
+        // Closing on the final ("All set") step counts as completing the flow; a mid-flow close keeps
+        // the persisted step so the next onboarding launch resumes there instead of restarting.
+        if !UserDefaults.standard.bool(forKey: Self.didCompleteKey),
+           Self.closeCompletesOnboarding(stepRaw: UserDefaults.standard.integer(forKey: Self.stepKey)) {
+            UserDefaults.standard.set(true, forKey: Self.didCompleteKey)
+        }
+    }
+
+    /// Pure (testable): does closing the window at this persisted step complete onboarding?
+    static func closeCompletesOnboarding(stepRaw: Int) -> Bool {
+        stepRaw >= OBStep.done.rawValue
+    }
+
+    /// Pure (testable): clamp a persisted raw step into the valid range (stale or corrupt values
+    /// fall back to the nearest valid step; an absent key reads as 0 = welcome).
+    static func clampedResumeStep(_ raw: Int, stepCount: Int) -> Int {
+        min(max(0, raw), stepCount - 1)
     }
 
     private func finish() {
         UserDefaults.standard.set(true, forKey: Self.didCompleteKey)
+        UserDefaults.standard.removeObject(forKey: Self.stepKey)
         window?.close()
     }
 }
@@ -132,20 +153,39 @@ private enum OBStep: Int, CaseIterable {
 private struct OnboardingRootView: View {
     let onFinish: () -> Void
 
-    @State private var step: OBStep = .welcome
+    @State private var step: OBStep
+    @State private var modelInstalled = false
+    @State private var modelSkipped = false
     @StateObject private var perms = PermissionsManager()
     private let permTick = Timer.publish(every: 1.5, on: .main, in: .common).autoconnect()
+
+    init(onFinish: @escaping () -> Void) {
+        self.onFinish = onFinish
+        // Resume a mid-flow close from the persisted step (0 = welcome when never persisted).
+        let raw = OnboardingWindowController.clampedResumeStep(
+            UserDefaults.standard.integer(forKey: OnboardingWindowController.stepKey),
+            stepCount: OBStep.allCases.count)
+        _step = State(initialValue: OBStep(rawValue: raw) ?? .welcome)
+    }
 
     private var requiredGranted: Bool {
         (perms.granted[.accessibility] ?? false) && (perms.granted[.inputMonitoring] ?? false)
     }
-    private var nextDisabled: Bool { step == .permissions && !requiredGranted }
+    private var nextDisabled: Bool {
+        switch step {
+        case .permissions: return !requiredGranted
+        case .model:       return !(modelInstalled || modelSkipped)
+        default:           return false
+        }
+    }
 
     var body: some View {
         HStack(spacing: 0) {
             OBRail(current: step) { tapped in
-                // Match the mock: you can jump back, or one step forward.
-                if tapped.rawValue <= step.rawValue || tapped.rawValue == step.rawValue + 1 {
+                // Match the mock: you can jump back, or one step forward — but a forward jump honors
+                // the same gate as the footer Continue (permissions granted / model installed-or-skipped).
+                if tapped.rawValue <= step.rawValue
+                    || (tapped.rawValue == step.rawValue + 1 && !nextDisabled) {
                     withAnimation(.easeOut(duration: 0.28)) { step = tapped }
                 }
             }
@@ -163,6 +203,9 @@ private struct OnboardingRootView: View {
         .onReceive(permTick) { _ in if step == .permissions { perms.refresh() } }
         .onReceive(NotificationCenter.default.publisher(
             for: NSApplication.didBecomeActiveNotification)) { _ in perms.refresh() }
+        .onChange(of: step) {
+            UserDefaults.standard.set(step.rawValue, forKey: OnboardingWindowController.stepKey)
+        }
     }
 
     @ViewBuilder private var stage: some View {
@@ -172,7 +215,10 @@ private struct OnboardingRootView: View {
                 case .welcome:     OBWelcome()
                 case .howItWorks:  OBHowItWorks()
                 case .permissions: OBPermissions(perms: perms)
-                case .model:       OBModelStep()
+                case .model:       OBModelStep(installed: $modelInstalled) {
+                                       modelSkipped = true
+                                       withAnimation(.easeOut(duration: 0.28)) { go(1) }
+                                   }
                 case .tryIt:       OBTryIt()
                 case .selectionRewrite: OBSelectionRewrite()
                 case .personalize: OBPersonalize()
@@ -205,7 +251,11 @@ private struct OnboardingRootView: View {
             }
             .buttonStyle(OBPrimaryButton(large: true))
             .disabled(nextDisabled)
-            .help(nextDisabled ? "Grant the two required permissions to continue" : "")
+            .help(nextDisabled
+                  ? (step == .permissions
+                     ? "Grant the two required permissions to continue"
+                     : "Download a model (or choose Skip for now) to continue")
+                  : "")
         }
         .padding(.horizontal, 30)
         .frame(height: 72)
@@ -548,6 +598,12 @@ private struct OBHowItWorks: View {
 private struct OBPermissions: View {
     @ObservedObject var perms: PermissionsManager
 
+    /// UserDefaults flag: this permission's system prompt has been fired once already. macOS only
+    /// shows each prompt once per app, so subsequent presses must fall back to System Settings.
+    static func requestedOnceKey(_ p: Permission) -> String {
+        "shadowtype.permRequestedOnce." + p.rawValue
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 26) {
             OBHeader(eyebrow: "Permissions",
@@ -596,9 +652,16 @@ private struct OBPermissions: View {
                 .foregroundStyle(OBTheme.good)
             } else {
                 Button(p.required ? "Grant access" : "Enable") {
+                    let key = Self.requestedOnceKey(p)
+                    let requestedBefore = UserDefaults.standard.bool(forKey: key)
                     perms.request(p)
-                    // The system prompt only fires once; also surface Settings for a prior denial.
-                    perms.openSettings(p)
+                    if requestedBefore {
+                        // The system prompt only fires once per app; on a repeat press Settings is
+                        // the only remaining path to the grant.
+                        perms.openSettings(p)
+                    } else {
+                        UserDefaults.standard.set(true, forKey: key)
+                    }
                 }
                 .buttonStyle(p.required ? AnyButtonStyle(OBPrimaryButton(small: true)) : AnyButtonStyle(OBGhostButton(small: true)))
             }
@@ -618,6 +681,11 @@ private struct AnyButtonStyle: ButtonStyle {
 // MARK: - Step 4: Language model (real ModelManager download)
 
 private struct OBModelStep: View {
+    /// Mirrors `phase == .installed` up to the root so the footer Continue can gate on it.
+    @Binding var installed: Bool
+    /// Advances past this step without a model ("Skip for now").
+    let onSkip: () -> Void
+
     private let manager = ModelManager()
     private let physicalBytes = ProcessInfo.processInfo.physicalMemory
 
@@ -630,7 +698,9 @@ private struct OBModelStep: View {
     @State private var progress: Double = 0     // 0...1
     @State private var phase: Phase = .idle
 
-    init() {
+    init(installed: Binding<Bool>, onSkip: @escaping () -> Void) {
+        _installed = installed
+        self.onSkip = onSkip
         let rec = ModelCatalog.recommended(
             physicalBytes: ProcessInfo.processInfo.physicalMemory)
         _selectedID = State(initialValue: rec.id)
@@ -701,8 +771,19 @@ private struct OBModelStep: View {
                     Button(primaryLabel) { startDownload() }
                         .buttonStyle(OBPrimaryButton())
                         .disabled(phase == .downloading || phase == .installed)
+                    if phase != .installed {
+                        Button("Skip for now") { onSkip() }
+                            .buttonStyle(OBGhostButton(small: true))
+                            .disabled(phase == .downloading)
+                    }
                 }
                 .padding(.top, 18)
+                if phase != .installed {
+                    Text("You can download a model later in Settings → Models — suggestions won't appear until then.")
+                        .font(.system(size: 11.5)).foregroundStyle(OBTheme.textFaint)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.top, 8)
+                }
             }
             .padding(20)
             .obCard()
@@ -717,7 +798,11 @@ private struct OBModelStep: View {
             }
             .padding(.top, 18)
         }
-        .onAppear { if isInstalled(selected) { phase = .installed; progress = 1 } }
+        .onAppear {
+            if isInstalled(selected) { phase = .installed; progress = 1 }
+            installed = (phase == .installed)
+        }
+        .onChange(of: phase) { installed = (phase == .installed) }
     }
 
     @ViewBuilder private func modelRow(_ entry: ModelCatalogEntry) -> some View {
@@ -882,9 +967,9 @@ private struct OBTryIt: View {
                 }
 
                 HStack(spacing: 6) {
-                    Text("Accepted").font(.system(size: 13)).foregroundStyle(OBTheme.textFaint)
                     Text("\(accepted)").font(.system(size: 13, weight: .semibold, design: .monospaced)).foregroundStyle(OBTheme.accentBright)
-                    Text("/ 100").font(.system(size: 13)).foregroundStyle(OBTheme.textFaint)
+                    Text(accepted == 1 ? "word accepted" : "words accepted")
+                        .font(.system(size: 13)).foregroundStyle(OBTheme.textFaint)
                     Text(flashText).font(.system(size: 13, weight: .semibold)).foregroundStyle(OBTheme.good)
                         .opacity(flash ? 1 : 0)
                         .padding(.leading, 8)
@@ -1057,6 +1142,13 @@ private struct OBPersonalize: View {
     @State private var name = ""
     @State private var languages = ""
     @State private var voice: InstructionStore.Voice = .friendly
+    // Debounced "Saved" feedback: the store writes live on every change; this flashes ~0.3s after
+    // typing stops so the user knows the edits stuck. Gated by didLoad so the onAppear prefill
+    // (which also fires onChange → seed) doesn't flash on entry.
+    @State private var savedFlash = false
+    @State private var didLoad = false
+    @State private var flashShowWork: DispatchWorkItem?
+    @State private var flashHideWork: DispatchWorkItem?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -1082,8 +1174,14 @@ private struct OBPersonalize: View {
 
             // Live preview of the composed instruction so the user sees exactly what gets seeded.
             VStack(alignment: .leading, spacing: 6) {
-                Text("WHAT SHADOWTYPE WILL USE").font(.system(size: 10.5, weight: .semibold))
-                    .tracking(1.3).foregroundStyle(OBTheme.textFaint)
+                HStack {
+                    Text("WHAT SHADOWTYPE WILL USE").font(.system(size: 10.5, weight: .semibold))
+                        .tracking(1.3).foregroundStyle(OBTheme.textFaint)
+                    Spacer()
+                    Text("Saved").font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(OBTheme.good)
+                        .opacity(savedFlash ? 1 : 0)
+                }
                 Text(InstructionStore.composeDefault(name: name, languages: languages, voice: voice))
                     .font(.system(size: 13)).foregroundStyle(OBTheme.textDim).lineSpacing(3)
                     .fixedSize(horizontal: false, vertical: true)
@@ -1098,6 +1196,8 @@ private struct OBPersonalize: View {
         .onAppear {
             let p = InstructionStore.shared.personalizationInputs()
             name = p.name; languages = p.languages; voice = p.voice ?? .friendly
+            // Let the prefill-triggered onChange/seed settle before flashes are allowed.
+            DispatchQueue.main.async { didLoad = true }
         }
         .onChange(of: name) { seed() }
         .onChange(of: languages) { seed() }
@@ -1107,6 +1207,22 @@ private struct OBPersonalize: View {
     private func seed() {
         InstructionStore.shared.seedGlobalFromPersonalization(
             name: name, languages: languages, voice: voice)
+        if didLoad { flashSaved() }
+    }
+
+    private func flashSaved() {
+        flashShowWork?.cancel()
+        flashHideWork?.cancel()
+        let show = DispatchWorkItem {
+            withAnimation(.easeIn(duration: 0.15)) { savedFlash = true }
+            let hide = DispatchWorkItem {
+                withAnimation(.easeOut(duration: 0.5)) { savedFlash = false }
+            }
+            flashHideWork = hide
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.4, execute: hide)
+        }
+        flashShowWork = show
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: show)
     }
 
     private func voicePill(_ v: InstructionStore.Voice) -> some View {
@@ -1125,6 +1241,7 @@ private struct OBPersonalize: View {
 
 private struct OBDone: View {
     @State private var launchAtLogin = LaunchAtLogin.isEnabled
+    @State private var launchError: String?
     @AppStorage("shadowtype.showWordCountInMenuBar") private var showWordCount = true
 
     var body: some View {
@@ -1150,7 +1267,20 @@ private struct OBDone: View {
 
             VStack(spacing: 0) {
                 optRow(title: "Launch at login", sub: "Always on, right when you sign in", isOn: $launchAtLogin)
-                    .onChange(of: launchAtLogin) { LaunchAtLogin.setEnabled(launchAtLogin) }
+                    .onChange(of: launchAtLogin) {
+                        switch LaunchAtLogin.setEnabled(launchAtLogin) {
+                        case .success:
+                            launchError = nil
+                        case .failure:
+                            launchError = "Couldn't \(launchAtLogin ? "enable" : "disable") — check System Settings → General → Login Items."
+                        }
+                    }
+                if let launchError {
+                    Text(launchError)
+                        .font(.system(size: 12)).foregroundStyle(OBTheme.warn)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.bottom, 10)
+                }
                 Divider().overlay(OBTheme.lineSoft)
                 optRow(title: "Show today's word count in menu bar",
                        sub: "See how many words you've accepted today at a glance", isOn: $showWordCount)

--- a/Sources/Shadowtype/OverlayRenderer.swift
+++ b/Sources/Shadowtype/OverlayRenderer.swift
@@ -37,19 +37,21 @@ final class OverlayRenderer {
         view.wantsLayer = true
         view.layer?.backgroundColor = NSColor.clear.cgColor
 
-        textLayer.foregroundColor = NSColor(white: 0.55, alpha: 0.6).cgColor   // faint but readable gray
+        textLayer.foregroundColor = Self.ghostTextColor(dark: Self.isDarkAppearance()).cgColor
         textLayer.contentsScale = NSScreen.main?.backingScaleFactor ?? 2
         textLayer.anchorPoint = .zero
         textLayer.position = .zero
         applyFont(currentFont)
         view.layer?.addSublayer(textLayer)
 
-        // Keycap: a faint outlined key (hintBg) with a centered label (hintLabel). Tuned to read on the
-        // LIGHT backgrounds the gray ghost already assumes — a subtle gray fill + hairline outline so the
-        // key shape is legible without shouting. Hidden until show(showHint:).
+        // Keycap: a faint outlined key (hintBg) with a centered label (hintLabel) — a subtle fill +
+        // hairline outline so the key shape is legible without shouting. Colors are appearance-adaptive
+        // and re-resolved on every show() (see applyAdaptiveColors); these are just the initial values.
+        // Hidden until show(showHint:).
         let scale = NSScreen.main?.backingScaleFactor ?? 2
-        hintBg.backgroundColor = NSColor(white: 0.5, alpha: 0.10).cgColor
-        hintBg.borderColor = NSColor(white: 0.5, alpha: 0.38).cgColor
+        let dark = Self.isDarkAppearance()
+        hintBg.backgroundColor = Self.hintBackgroundColor(dark: dark).cgColor
+        hintBg.borderColor = Self.hintBorderColor(dark: dark).cgColor
         hintBg.borderWidth = 1
         hintBg.cornerRadius = 5
         hintBg.contentsScale = scale
@@ -57,7 +59,7 @@ final class OverlayRenderer {
         hintBg.isHidden = true
         view.layer?.addSublayer(hintBg)
 
-        hintLabel.foregroundColor = NSColor(white: 0.42, alpha: 0.95).cgColor
+        hintLabel.foregroundColor = Self.hintLabelColor(dark: dark).cgColor
         hintLabel.alignmentMode = .center
         hintLabel.contentsScale = scale
         hintLabel.anchorPoint = .zero
@@ -65,6 +67,46 @@ final class OverlayRenderer {
         view.layer?.addSublayer(hintLabel)
 
         panel.contentView = view
+    }
+
+    // MARK: - Appearance-adaptive colors
+    // The overlay panel is borderless + clear, so system dynamic colors would resolve against no real
+    // background — pick explicit per-appearance values instead. Pure (testable); the dark variants
+    // lighten text/borders so the ghost and keycap stay legible on dark host backgrounds, while the
+    // light-mode values are exactly the pre-adaptive ones.
+
+    // Faint but readable gray for the ghost text.
+    static func ghostTextColor(dark: Bool) -> NSColor {
+        dark ? NSColor(white: 0.70, alpha: 0.6) : NSColor(white: 0.55, alpha: 0.6)
+    }
+
+    static func hintBackgroundColor(dark: Bool) -> NSColor {
+        dark ? NSColor(white: 0.85, alpha: 0.12) : NSColor(white: 0.5, alpha: 0.10)
+    }
+
+    static func hintBorderColor(dark: Bool) -> NSColor {
+        dark ? NSColor(white: 0.85, alpha: 0.40) : NSColor(white: 0.5, alpha: 0.38)
+    }
+
+    static func hintLabelColor(dark: Bool) -> NSColor {
+        dark ? NSColor(white: 0.80, alpha: 0.95) : NSColor(white: 0.42, alpha: 0.95)
+    }
+
+    // Effective system appearance at resolve time. NSApp is nil under `swift test` (no app instance);
+    // fall back to light, matching the historical hardcoded colors.
+    private static func isDarkAppearance() -> Bool {
+        guard let appearance = NSApp?.effectiveAppearance else { return false }
+        return appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+    }
+
+    // Re-resolve the adaptive layer colors. Called on each show() so a light/dark switch takes effect
+    // on the next ghost without a relaunch (the panel never gets viewDidChangeEffectiveAppearance).
+    private func applyAdaptiveColors() {
+        let dark = Self.isDarkAppearance()
+        textLayer.foregroundColor = Self.ghostTextColor(dark: dark).cgColor
+        hintBg.backgroundColor = Self.hintBackgroundColor(dark: dark).cgColor
+        hintBg.borderColor = Self.hintBorderColor(dark: dark).cgColor
+        hintLabel.foregroundColor = Self.hintLabelColor(dark: dark).cgColor
     }
 
     // Keycap font tracks the ghost size but stays compact and never larger than the host text.
@@ -93,6 +135,7 @@ final class OverlayRenderer {
 
         CATransaction.begin()
         CATransaction.setDisableActions(true)
+        applyAdaptiveColors()   // re-resolve per show so a light/dark switch takes effect
         textLayer.string = display
         textLayer.opacity = Float(max(0, min(1, opacity)))
 
@@ -150,6 +193,11 @@ final class OverlayRenderer {
         panel.orderOut(nil)
     }
 
+    // Pure geometry for the RTL anchor: right edge at the caret, clamped to the screen's left edge.
+    static func rtlOriginX(caretMinX: CGFloat, width: CGFloat, screenMinX: CGFloat) -> CGFloat {
+        max(screenMinX, caretMinX - width)
+    }
+
     // Cap visible length so a runaway suggestion can't produce a 700px-wide panel; append an ellipsis.
     static func truncated(_ text: String, max: Int) -> String {
         guard text.count > max, max > 0 else { return text }
@@ -169,8 +217,19 @@ final class OverlayRenderer {
         }
         // caretRect.maxY is the caret baseline area; AppKit windows are bottom-left origin.
         // #11: in a right-to-left field the continuation flows leftward, so anchor the panel's RIGHT
-        // edge at the caret (origin shifted left by the panel width) instead of its left edge.
-        let x = rtl ? caretRect.minX - width : caretRect.minX
+        // edge at the caret (origin shifted left by the panel width) instead of its left edge — clamped
+        // to the caret's screen so a wide ghost near the left bezel can't slide off-screen (it then
+        // overlaps the caret's left side instead of disappearing). Screen resolved by containment of
+        // the caret point, the same way show() resolves the backing scale.
+        let x: CGFloat
+        if rtl {
+            let screen = NSScreen.screens
+                .first { $0.frame.contains(CGPoint(x: caretRect.minX, y: caretRect.maxY)) }?.frame
+                ?? NSScreen.main?.frame ?? .zero
+            x = Self.rtlOriginX(caretMinX: caretRect.minX, width: width, screenMinX: screen.minX)
+        } else {
+            x = caretRect.minX
+        }
         return CGPoint(x: x, y: caretRect.maxY - height)
     }
 }

--- a/Sources/Shadowtype/RewriteKeyTap.swift
+++ b/Sources/Shadowtype/RewriteKeyTap.swift
@@ -2,7 +2,7 @@
 // intercepts the three control keys the HUD offers so they don't reach the host app, and treats any
 // other key as "commit and get out of the way":
 //   • Return / Enter   → onKeep      (swallowed — Return would otherwise send the Slack/Mail message)
-//   • ⌘R               → onRegenerate (swallowed)
+//   • ⌘R               → onRegenerate (swallowed when shouldSwallowRegenerate(); else other-key)
 //   • Escape           → onUndo      (swallowed)
 //   • anything else     → onOtherKey (passed through so the user's typing isn't lost) then teardown
 // Modeled on TabSwallowTap (active .defaultTap at the head of the session tap; returning nil deletes the
@@ -15,6 +15,10 @@ final class RewriteKeyTap {
     var onRegenerate: (() -> Void)?
     var onUndo: (() -> Void)?
     var onOtherKey: (() -> Void)?
+    // Whether ⌘R is one of OURS right now. Web sessions don't offer redo, so swallowing ⌘R there
+    // would dead-key the browser's reload — when this returns false, ⌘R takes the other-key path
+    // (commit + pass through to the host). Default: swallow (native behavior).
+    var shouldSwallowRegenerate: () -> Bool = { true }
 
     private var tap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
@@ -56,8 +60,13 @@ final class RewriteKeyTap {
                     return nil
                 }
                 if cmd && code == RewriteKeyTap.kR {
-                    me.onRegenerate?()
-                    return nil
+                    if me.shouldSwallowRegenerate() {
+                        me.onRegenerate?()
+                        return nil
+                    }
+                    // Not ours (web session): commit like any other key and let the host see ⌘R.
+                    me.onOtherKey?()
+                    return Unmanaged.passUnretained(event)
                 }
                 // Any other key commits the rewrite and dismisses; pass the key through to the app.
                 me.onOtherKey?()

--- a/Sources/Shadowtype/SelectionRewriteController.swift
+++ b/Sources/Shadowtype/SelectionRewriteController.swift
@@ -37,6 +37,7 @@ final class SelectionRewriteController: NSObject {
     // the HUD-hint wait and a stuck generation. Installed for the whole active flow, torn down on exit.
     private var mouseMonitor: Any?
     private var workspaceObserver: NSObjectProtocol?
+    private var spaceObserver: NSObjectProtocol?
     private var watchdog: Timer?
     private static let watchdogSeconds: TimeInterval = 30
 
@@ -58,6 +59,11 @@ final class SelectionRewriteController: NSObject {
         keyTap.onUndo = { [weak self] in self?.undo() }
         keyTap.onRegenerate = { [weak self] in self?.regenerate() }
         keyTap.onOtherKey = { [weak self] in self?.keep() }
+        // ⌘R is only OURS on native sessions (the HUD offers "⌘R redo" there). On web sessions the
+        // HUD never offers redo, so swallowing ⌘R would dead-key the browser's reload — let the tap
+        // treat it as "other key" (commit + pass through) instead. While generating (no session yet)
+        // keep swallowing: regenerate() no-ops and Reload mid-rewrite would yank the field away.
+        keyTap.shouldSwallowRegenerate = { [weak self] in self?.session?.native ?? true }
     }
 
     // MARK: - Entry (global hotkey)
@@ -115,6 +121,12 @@ final class SelectionRewriteController: NSObject {
     // MARK: - Generate + place
 
     private func run(action: RewriteAction, selection sel: EditContextTracker.CurrentSelection) {
+        // A generic "Couldn't rewrite" when the model simply hasn't finished loading reads like a
+        // bug; tell the user the real reason and bail before arming any flow state.
+        guard coordinator.isEngineLoaded else {
+            toast("Model not ready — still loading")
+            return
+        }
         coordinator.rewriteActive = true
         hud.showWorking(at: anchor)
         // Arm the key tap NOW, before the async decode — otherwise a Return pressed during "Rewriting…"
@@ -237,21 +249,29 @@ final class SelectionRewriteController: NSObject {
         coordinator.rewriteActive = false
     }
 
-    private func fail() {
+    private func fail(message: String = "Couldn't rewrite — try again") {
         keyTap.disarm()           // armed in run(); must come down on the failure path too
         removeDismissGuards()
         coordinator.rewriteActive = false
         session = nil
-        hud.showHint(at: anchor, text: "Couldn't rewrite — try again")
+        hud.showHint(at: anchor, text: message)
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) { [weak self] in self?.hud.hide() }
     }
 
     // Hard timeout backstop: started when generation begins so `rewriteActive` (which suppresses ALL
     // ghost completions) can never stay set if a decode hangs or every dismissal path is missed.
+    // No session yet means generation never finished — that's an error the user should hear about,
+    // not a silent keep() of nothing. With a session up (result showing), committing is correct.
     private func startWatchdog() {
         watchdog?.invalidate()
         watchdog = Timer.scheduledTimer(withTimeInterval: Self.watchdogSeconds, repeats: false) {
-            [weak self] _ in self?.keep()
+            [weak self] _ in
+            guard let self else { return }
+            if self.session == nil {
+                self.fail(message: "Rewrite timed out — try again")
+            } else {
+                self.keep()
+            }
         }
     }
 
@@ -269,11 +289,20 @@ final class SelectionRewriteController: NSObject {
                     [weak self] _ in self?.keep()
                 }
         }
+        // A Spaces switch (Ctrl-←/→, Mission Control) moves the user away without an app activation,
+        // leaving the HUD floating over the wrong Space's content. Treat it exactly like app switch.
+        if spaceObserver == nil {
+            spaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
+                forName: NSWorkspace.activeSpaceDidChangeNotification, object: nil, queue: .main) {
+                    [weak self] _ in self?.keep()
+                }
+        }
     }
 
     private func removeDismissGuards() {
         if let m = mouseMonitor { NSEvent.removeMonitor(m); mouseMonitor = nil }
         if let o = workspaceObserver { NSWorkspace.shared.notificationCenter.removeObserver(o); workspaceObserver = nil }
+        if let o = spaceObserver { NSWorkspace.shared.notificationCenter.removeObserver(o); spaceObserver = nil }
         watchdog?.invalidate(); watchdog = nil
     }
 

--- a/Sources/Shadowtype/SettingsWindow.swift
+++ b/Sources/Shadowtype/SettingsWindow.swift
@@ -16,9 +16,16 @@ import ApplicationServices
 // AppDelegate observes it and downloads (if needed) + swaps the active model live on the inference queue.
 extension Notification.Name {
     static let shadowtypeSelectModel = Notification.Name("shadowtype.selectModel")
-    // Posted by AppDelegate after a live swap finishes; userInfo ["id": String, "ok": Bool].
+    // Posted by AppDelegate after a live swap finishes; userInfo ["id": String, "ok": Bool] plus
+    // an optional ["error": String] failure reason when ok == false.
     // The Models pane clears its download spinner and reverts the picker if the swap failed.
     static let shadowtypeModelDidChange = Notification.Name("shadowtype.modelDidChange")
+    // Posted by AppDelegate while a catalog download is in flight; userInfo ["id": String,
+    // "fraction": Double] — "fraction" absent while the total size is unknown (indeterminate).
+    static let shadowtypeModelDownloadProgress = Notification.Name("shadowtypeModelDownloadProgress")
+    // Posted by the General pane when the rewrite-hotkey chord (UserDefaults
+    // "shadowtype.rewriteHotkeyChord") changes; AppDelegate re-registers the global hotkey.
+    static let shadowtypeRewriteHotkeyChanged = Notification.Name("shadowtypeRewriteHotkeyChanged")
 }
 
 final class SettingsWindowController: NSObject, NSWindowDelegate {
@@ -325,6 +332,9 @@ private struct GeneralPane: View {
     // Real: AppDelegate.syncToggles mirrors this into the active-field badge (default on).
     @AppStorage("shadowtype.showActiveBadge") private var showActiveBadge = true
     @AppStorage("shadowtype.showTabHint") private var showTabHint = true
+    // Rewrite-selection hotkey chord. AppDelegate observes .shadowtypeRewriteHotkeyChanged and
+    // re-registers the global hotkey when this changes.
+    @AppStorage("shadowtype.rewriteHotkeyChord") private var rewriteHotkeyChord = "opt-cmd-k"
 
     // Reads/writes the real CompletionLength key; all lengths are available.
     private var lengthBinding: Binding<CompletionLength> {
@@ -409,6 +419,18 @@ private struct GeneralPane: View {
                 caption("Show a faint “⇥ Tab” keycap next to the ghost text so you remember the accept key. It fades away on its own once you've accepted a few suggestions.")
             }
 
+            Section("Rewrite") {
+                Picker("Rewrite shortcut", selection: $rewriteHotkeyChord) {
+                    Text("⌥⌘K (default)").tag("opt-cmd-k")
+                    Text("⌃⌘K").tag("ctrl-cmd-k")
+                    Text("⌥⌘J").tag("opt-cmd-j")
+                }
+                .onChange(of: rewriteHotkeyChord) {
+                    NotificationCenter.default.post(name: .shadowtypeRewriteHotkeyChanged, object: nil)
+                }
+                caption("⌥⌘K can conflict with Apple Writing Tools in some apps.")
+            }
+
             Section("Typo handling") {
                 Toggle("Hold back suggestions on likely typos", isOn: $holdBackOnTypos)
                 caption("Suppress ghost text when the last word looks mistyped, instead of completing nonsense.")
@@ -445,7 +467,15 @@ private struct ModelsPane: View {
     @State private var unlocked = Entitlement.isUnlocked
     @State private var installed: Set<String> = []
     @State private var downloading: String?
-    @State private var freeDisk = ""           // computed once on appear, not per-render
+    // Live download progress for `downloading` (0...1), nil while the total size is unknown.
+    // Fed by .shadowtypeModelDownloadProgress (posted by AppDelegate).
+    @State private var downloadFraction: Double?
+    // Last failed download/swap reason, from .shadowtypeModelDidChange userInfo["error"].
+    // Cleared on the next apply()/successful swap.
+    @State private var downloadError: String?
+    // Imported entry pending the "Remove" confirmation dialog.
+    @State private var removeCandidate: ImportedModelEntry?
+    @State private var freeDisk = ""           // recomputed by rescan(), not per-render
 
     private let manager = ModelManager()
     private var physicalBytes: UInt64 { ProcessInfo.processInfo.physicalMemory }
@@ -467,17 +497,40 @@ private struct ModelsPane: View {
         return ModelCatalog.entries.first { $0.id == selectedID } ?? ModelCatalog.entries[0]
     }
 
+    // Whether the selected model's file is actually on disk — drives the Active-model pill and
+    // gates "Reveal in Finder" (revealing a non-existent file just opens an unrelated folder).
+    private var activeModelFileExists: Bool {
+        FileManager.default.fileExists(atPath: manager.modelURL(for: selectedEntry).path)
+    }
+
+    // Derived Active-model state: a download in flight beats everything (apply() only ever starts a
+    // download for the model it just selected), then installed vs missing-on-disk.
+    @ViewBuilder private var activeModelPill: some View {
+        if downloading != nil {
+            Pill(text: "Downloading…", kind: .warn)
+        } else if activeModelFileExists {
+            Pill(text: "Loaded", kind: .good)
+        } else {
+            Pill(text: "Not downloaded", kind: .warn)
+        }
+    }
+
     var body: some View {
         Form {
             Callout(systemImage: "lock.fill",
                     text: "**All inference runs on this Mac** via llama.cpp + Metal. Models download once over HTTPS, are verified by SHA-256, and never phone home during completion.")
+
+            if let err = downloadError {
+                Callout(systemImage: "exclamationmark.triangle.fill",
+                        text: LocalizedStringKey(err), tint: .orange)
+            }
 
             Section("Active model") {
                 HStack(alignment: .top) {
                     VStack(alignment: .leading, spacing: 3) {
                         HStack(spacing: 6) {
                             Text(selectedEntry.name).fontWeight(.semibold)
-                            Pill(text: "Loaded", kind: .good)
+                            activeModelPill
                         }
                         Text(modelSpec(selectedEntry))
                             .font(.caption).foregroundStyle(.secondary)
@@ -487,6 +540,7 @@ private struct ModelsPane: View {
                         NSWorkspace.shared.activateFileViewerSelecting([manager.modelURL(for: selectedEntry)])
                     }
                     .controlSize(.small)
+                    .disabled(!activeModelFileExists)
                 }
                 .padding(.vertical, 2)
 
@@ -577,7 +631,7 @@ private struct ModelsPane: View {
         }
         .formStyle(.grouped)
         .navigationTitle("Models")
-        .onAppear { rescan(); freeDisk = Self.computeFreeDisk(); importedEntries = ImportedModelStore.shared.entries() }
+        .onAppear { rescan(); importedEntries = ImportedModelStore.shared.entries() }
         .sheet(isPresented: $hfSheetVisible) {
             HFImportSheet { newEntry in
                 importedEntries = ImportedModelStore.shared.entries()
@@ -588,12 +642,53 @@ private struct ModelsPane: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .shadowtypeModelDidChange)) { note in
             downloading = nil
+            downloadFraction = nil
             rescan()
             if let id = note.userInfo?["id"] as? String,
-               note.userInfo?["ok"] as? Bool == false,
-               selectedID == id {
-                selectedID = ModelCatalog.entries[0].id
+               note.userInfo?["ok"] as? Bool == false {
+                downloadError = (note.userInfo?["error"] as? String)
+                    ?? "Download failed — check disk space and network."
+                if selectedID == id { selectedID = ModelCatalog.entries[0].id }
+            } else {
+                downloadError = nil
             }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .shadowtypeModelDownloadProgress)) { note in
+            guard let id = note.userInfo?["id"] as? String, id == downloading else { return }
+            downloadFraction = note.userInfo?["fraction"] as? Double
+        }
+        .confirmationDialog(
+            "Remove \u{201C}\(removeCandidate?.name ?? "model")\u{201D}?",
+            isPresented: Binding(get: { removeCandidate != nil },
+                                 set: { if !$0 { removeCandidate = nil } }),
+            titleVisibility: .visible,
+            presenting: removeCandidate
+        ) { entry in
+            Button("Remove", role: .destructive) { confirmRemove(entry) }
+            Button("Cancel", role: .cancel) {}
+        } message: { entry in
+            if entry.id == selectedID {
+                Text("This model is currently active — suggestions will stop until another model is selected. Shadowtype will switch to \u{201C}\(removalFallbackEntry.name)\u{201D} after removal. Your original .gguf file on disk is not deleted.")
+            } else {
+                Text("This removes the import from Shadowtype. Your original .gguf file on disk is not deleted.")
+            }
+        }
+    }
+
+    // The catalog entry we auto-select after removing the ACTIVE imported model: the first
+    // recommended (RAM-fitting) entry, falling back to the shipping default.
+    private var removalFallbackEntry: ModelCatalogEntry {
+        ModelCatalog.entries.first { ModelCatalog.ramOK(for: $0, physicalBytes: physicalBytes) }
+            ?? ModelCatalog.entries[0]
+    }
+
+    private func confirmRemove(_ entry: ImportedModelEntry) {
+        let wasActive = entry.id == selectedID
+        ImportedModelStore.shared.remove(id: entry.id)
+        importedEntries = ImportedModelStore.shared.entries()
+        if wasActive {
+            // Re-point the engine at a real model so suggestions come back without a manual pick.
+            apply(to: removalFallbackEntry.id)
         }
     }
 
@@ -608,22 +703,31 @@ private struct ModelsPane: View {
                 HStack(spacing: 6) {
                     Text(entry.name).fontWeight(.medium)
                     if isActive { Pill(text: "Active", kind: .good) }
+                    if entry.isInstruct { Pill(text: "Instruct", kind: .warn) }
                 }
                 Text(libraryDetail(entry, ramOK: ramOK))
                     .font(.caption).foregroundStyle(.secondary)
             }
             Spacer()
             if downloading == entry.id {
-                ProgressView().controlSize(.small)
+                if let fraction = downloadFraction {
+                    ProgressView(value: fraction).frame(width: 90)
+                    Text("\(Int(fraction * 100))%")
+                        .font(.caption.monospaced()).foregroundStyle(.secondary)
+                } else {
+                    ProgressView().controlSize(.small)
+                }
             } else if isActive {
                 Button("In use") {}.disabled(true).controlSize(.small)
             } else if isInstalled {
                 Pill(text: "Downloaded", kind: .good)
                 Button("Switch to") { apply(to: entry.id) }.controlSize(.small)
+                    .disabled(downloading != nil)   // no mid-download switch race
             } else {
                 Text(gb(entry.downloadGB)).font(.caption.monospaced()).foregroundStyle(.secondary)
                 Button("Download") { apply(to: entry.id) }
                     .controlSize(.small).buttonStyle(.borderedProminent)
+                    .disabled(downloading != nil)   // one download at a time
             }
         }
         .padding(.vertical, 2)
@@ -661,11 +765,15 @@ private struct ModelsPane: View {
             present.insert(entry.id)
         }
         installed = present
+        // Free space changes with every download/removal, so refresh it alongside the install scan.
+        freeDisk = Self.computeFreeDisk()
     }
 
     // Posts the live-swap request (AppDelegate downloads-if-needed + swaps on the inference queue,
     // then posts .shadowtypeModelDidChange).
     private func apply(to newID: String) {
+        downloadError = nil
+        downloadFraction = nil
         // M3 BYOM: imported IDs route through ImportedModelStore so the swap notification carries
         // a synthesized ModelCatalogEntry pointing at the symlink. No download path; AppDelegate
         // calls swapModel which calls ensureModel which (for byom-) short-circuits to the path.
@@ -705,12 +813,10 @@ private struct ModelsPane: View {
             } else {
                 Button("Switch to") { apply(to: entry.id) }
                     .controlSize(.small)
+                    .disabled(downloading != nil)   // no mid-download switch race
             }
-            Button("Remove") {
-                ImportedModelStore.shared.remove(id: entry.id)
-                importedEntries = ImportedModelStore.shared.entries()
-            }
-            .controlSize(.small)
+            Button("Remove") { removeCandidate = entry }
+                .controlSize(.small)
         }
         .padding(.vertical, 2)
     }
@@ -930,15 +1036,20 @@ private struct AppsDomainsPane: View {
     }
 
     private var addBar: some View {
-        HStack(spacing: 6) {
-            TextField("Add bundle id or domain…", text: $addText)
-                .textFieldStyle(.roundedBorder).font(.caption)
-            Menu {
-                Button("Add as app") { addTarget(isApp: true) }
-                Button("Add as domain") { addTarget(isApp: false) }
-            } label: { Image(systemName: "plus") }
-                .menuStyle(.borderlessButton).fixedSize()
-                .disabled(addText.trimmingCharacters(in: .whitespaces).isEmpty)
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                TextField("Add bundle id or domain…", text: $addText)
+                    .textFieldStyle(.roundedBorder).font(.caption)
+                Menu {
+                    Button("Add as app") { addTarget(isApp: true) }
+                    Button("Add as domain") { addTarget(isApp: false) }
+                } label: { Image(systemName: "plus") }
+                    .menuStyle(.borderlessButton).fixedSize()
+                    .disabled(addText.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+            Text("Domain rules match subdomains too — “google.com” also matches “mail.google.com”.")
+                .font(.caption2).foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
         .padding(8)
     }
@@ -1346,18 +1457,31 @@ private struct ShortcutsPane: View {
     @AppStorage("shadowtype.emojiShortcode") private var emojiShortcode = true
     @AppStorage("shadowtype.rewriteEnabled") private var rewriteEnabled = true
 
+    @AppStorage("shadowtype.rewriteHotkeyChord") private var rewriteChord = "opt-cmd-k"
+
     private struct Shortcut: Identifiable {
         let id = UUID(); let action: String; let note: String; let keys: [String]?
     }
-    private let shortcuts: [Shortcut] = [
+    // Keycap symbols for the configurable rewrite chord (General pane picker).
+    private var rewriteChordKeys: [String] {
+        switch rewriteChord {
+        case "ctrl-cmd-k": return ["⌃", "⌘", "K"]
+        case "opt-cmd-j":  return ["⌥", "⌘", "J"]
+        default:           return ["⌥", "⌘", "K"]
+        }
+    }
+    private var rewriteChordLabel: String { rewriteChordKeys.joined() }
+
+    private var shortcuts: [Shortcut] { staticShortcuts(rewriteKeys: rewriteChordKeys) }
+    private func staticShortcuts(rewriteKeys: [String]) -> [Shortcut] { [
         .init(action: "Accept next word", note: "Take one word from the current suggestion. Right Arrow also works at end-of-line when enabled.", keys: ["Tab"]),
         .init(action: "Accept whole line", note: "Take the entire suggested line at once.", keys: ["⌥", "Tab"]),
         .init(action: "Dismiss suggestion", note: "Hide the current ghost text. Typing also dismisses.", keys: ["esc"]),
         .init(action: "Force suggestions here", note: "Turn completions on in the current field, even where Shadowtype stays idle (terminals, code editors).", keys: ["⌃", "`"]),
-        .init(action: "Rewrite selection", note: "Rewrite the selected text on-device — improve, shorten, change tone, fix grammar, or summarize. Preview before keeping.", keys: ["⌥", "⌘", "K"]),
+        .init(action: "Rewrite selection", note: "Rewrite the selected text on-device — improve, shorten, change tone, fix grammar, or summarize. Preview before keeping.", keys: rewriteKeys),
         .init(action: "Toggle Shadowtype on/off", note: "Global hotkey to pause and resume everywhere.", keys: nil),
         .init(action: "Pause for current app", note: "Temporarily disable in the frontmost app.", keys: ["⌃", "⌥", "P"]),
-    ]
+    ] }
 
     var body: some View {
         Form {
@@ -1375,7 +1499,7 @@ private struct ShortcutsPane: View {
                     .padding(.vertical, 1)
                 }
             } footer: {
-                Text("Accept/dismiss keys are fixed in the Free tier.")
+                Text("Accept and dismiss keys are fixed; the rewrite shortcut is configurable in General.")
             }
 
             Section {
@@ -1385,8 +1509,8 @@ private struct ShortcutsPane: View {
                 caption("Accept the next word with Right Arrow when the caret is at end-of-line. Matches Smart Compose and Superhuman. Cursor motion still wins mid-line or with any modifier held.")
                 Toggle("Emoji shortcode", isOn: $emojiShortcode)
                 caption("Type “:” then a name to insert emoji. Turn off to disable the trigger entirely.")
-                Toggle("Selection rewrite (⌥⌘K)", isOn: $rewriteEnabled)
-                caption("Rewrite selected text on-device with a local model. Off disables the ⌥⌘K hotkey.")
+                Toggle("Selection rewrite (\(rewriteChordLabel))", isOn: $rewriteEnabled)
+                caption("Rewrite selected text on-device with a local model. Off disables the \(rewriteChordLabel) hotkey. Change the shortcut in General.")
             }
         }
         .formStyle(.grouped)
@@ -1403,6 +1527,7 @@ private struct PersonalizationPane: View {
     @AppStorage("shadowtype.personalizationStrength") private var strength = 3
     @State private var phrases = 0
     @State private var sizeText = "Empty"
+    @State private var wipeConfirmVisible = false
 
     private static let strengthLabels = ["Off", "Light", "Medium", "Strong"]
 
@@ -1440,8 +1565,17 @@ private struct PersonalizationPane: View {
                 }
                 LabeledContent("Profile storage", value: sizeText)
                 Button("Wipe my profile", role: .destructive) {
-                    StyleProfile.shared.wipe()
-                    refresh()
+                    wipeConfirmVisible = true
+                }
+                .confirmationDialog("Wipe your writing-style profile?",
+                                    isPresented: $wipeConfirmVisible, titleVisibility: .visible) {
+                    Button("Wipe Profile", role: .destructive) {
+                        StyleProfile.shared.wipe()
+                        refresh()
+                    }
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text("This permanently deletes everything Shadowtype has learned about your writing style on this Mac. It can’t be undone.")
                 }
             }
         }
@@ -1466,8 +1600,12 @@ private struct InstructionsPane: View {
     @State private var perApp: [String: String] = [:]
     @State private var newBundleId = ""
     @State private var newInstruction = ""
+    @State private var resetFlash = false   // brief "Reset to default." confirmation flash
 
     private var sortedBundleIds: [String] { perApp.keys.sorted() }
+    private var trimmedNewBundleId: String {
+        newBundleId.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 
     var body: some View {
         Form {
@@ -1487,9 +1625,17 @@ private struct InstructionsPane: View {
                 HStack {
                     Text("Custom AI Instructions")
                     Spacer()
+                    if resetFlash {
+                        Text("Reset to default.")
+                            .font(.caption).foregroundStyle(.secondary)
+                            .textCase(nil)
+                            .transition(.opacity)
+                    }
                     Button("Reset to Default") {
                         InstructionStore.shared.resetGlobalToDefault()
                         refresh()
+                        resetFlash = true
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { resetFlash = false }
                     }
                     .buttonStyle(.borderless)
                     .controlSize(.small)
@@ -1528,18 +1674,23 @@ private struct InstructionsPane: View {
                           prompt: Text("App bundle id (e.g. com.tinyspeck.slackmacgap)"))
                     .labelsHidden()
                     .font(.system(.body, design: .monospaced))
+                if !trimmedNewBundleId.isEmpty && !BundleIDValidator.isValid(trimmedNewBundleId) {
+                    Text("Not a valid bundle id — use at least two dot-separated parts of letters, digits, or hyphens (e.g. com.apple.mail).")
+                        .font(.caption).foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
                 TextField("Instruction for that app", text: $newInstruction,
                           prompt: Text("Instruction for that app"), axis: .vertical)
                     .labelsHidden()
                     .lineLimit(2...5)
                 Button("Add override") {
-                    let bid = newBundleId.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !bid.isEmpty else { return }
+                    let bid = trimmedNewBundleId
+                    guard BundleIDValidator.isValid(bid) else { return }
                     InstructionStore.shared.setInstruction(newInstruction, forBundleId: bid)
                     newBundleId = ""; newInstruction = ""
                     refresh()
                 }
-                .disabled(newBundleId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .disabled(!BundleIDValidator.isValid(trimmedNewBundleId))
             }
         }
         .formStyle(.grouped)
@@ -1560,6 +1711,25 @@ private struct InstructionsPane: View {
                 InstructionStore.shared.setInstruction(newValue, forBundleId: bundleId)
             }
         )
+    }
+}
+
+// Pure bundle-id shape check for the "Add override" field. Internal (not private) so unit tests
+// can exercise it directly. Deliberately ASCII-strict: real CFBundleIdentifiers are reverse-DNS
+// of ASCII letters/digits/hyphens — anything else is almost certainly a typo in this field.
+enum BundleIDValidator {
+    /// True when `raw` (whitespace-trimmed) has ≥2 dot-separated components, each non-empty and
+    /// containing only ASCII letters, digits, or hyphens.
+    static func isValid(_ raw: String) -> Bool {
+        let s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = s.components(separatedBy: ".")
+        guard parts.count >= 2 else { return false }
+        return parts.allSatisfy { part in
+            !part.isEmpty && part.unicodeScalars.allSatisfy {
+                ("a"..."z").contains($0) || ("A"..."Z").contains($0)
+                    || ("0"..."9").contains($0) || $0 == "-"
+            }
+        }
     }
 }
 
@@ -1714,7 +1884,19 @@ private struct AboutPane: View {
         case .readyToInstall(let m):
             Pill(text: "Ready to install — v\(m.version)", kind: .good)
         case .failed(let msg):
-            Pill(text: msg, kind: .warn)
+            // Show the actual failure reason (a pill truncates poorly for long messages) plus a
+            // one-click retry of the same check/stage flow the manual button runs.
+            VStack(alignment: .trailing, spacing: 4) {
+                Text(msg)
+                    .font(.caption).foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .multilineTextAlignment(.trailing)
+                Button("Try again") {
+                    let channel: UpdateChannel = includeBeta ? .beta : .stable
+                    Task { await updater.checkThenStage(channel: channel, manual: true) }
+                }
+                .controlSize(.small)
+            }
         }
     }
 }
@@ -1782,17 +1964,25 @@ final class PermissionsManager: ObservableObject {
     }
 
     // Screen Recording is the only thing the OCR context feature needs. The first time we observe it
-    // granted, flip the on-screen OCR toggle on for the user (FR-CTX-1) — that's the whole point of
-    // granting it. Gated by a one-time persisted flag so we don't re-enable on every poll (or fight a
-    // user who later turns OCR back off). Revoking Screen Recording clears the flag, so a future
-    // re-grant auto-enables again.
+    // granted, OFFER to enable on-screen OCR (FR-CTX-1) — never flip it silently: the user may have
+    // granted Screen Recording for an unrelated reason, and "app starts reading my screen" must be an
+    // explicit choice. Gated by a one-time persisted flag so the offer doesn't repeat on every poll.
+    // Revoking Screen Recording clears the flag, so a future re-grant offers again.
     private func autoEnableOCRIfScreenRecordingGranted(_ granted: Bool) {
         let defaults = UserDefaults.standard
         let flagKey = "shadowtype.ocrAutoEnabledForScreenRecording"
         if granted {
             guard !defaults.bool(forKey: flagKey) else { return }
-            defaults.set(true, forKey: "shadowtype.useScreenOCR")
             defaults.set(true, forKey: flagKey)
+            guard !defaults.bool(forKey: "shadowtype.useScreenOCR") else { return }
+            let alert = NSAlert()
+            alert.messageText = "Use screen text for context?"
+            alert.informativeText = "Screen Recording is now granted. Shadowtype can read on-screen text near where you type to improve suggestions — entirely on-device, nothing leaves your Mac. You can change this anytime in Settings → Context."
+            alert.addButton(withTitle: "Enable")
+            alert.addButton(withTitle: "Not Now")
+            if alert.runModal() == .alertFirstButtonReturn {
+                defaults.set(true, forKey: "shadowtype.useScreenOCR")
+            }
         } else {
             defaults.set(false, forKey: flagKey)
         }

--- a/Sources/Shadowtype/StatusItemController.swift
+++ b/Sources/Shadowtype/StatusItemController.swift
@@ -121,7 +121,7 @@ final class StatusItemController: NSObject {
 
         enableItem.target = self
         enableItem.action = #selector(toggleEnabled)
-        enableItem.state = isEnabled ? .on : .off
+        setEnabled(isEnabled)   // sync title + checkmark with the initial enabled state
         menu.addItem(enableItem)
 
         menu.addItem(.separator())

--- a/Sources/Shadowtype/UpdateManager.swift
+++ b/Sources/Shadowtype/UpdateManager.swift
@@ -57,18 +57,22 @@ final class UpdateManager: ObservableObject {
 
     private let apiBase: URL                  // https://api.github.com/repos/<owner>/<repo>
     private let session: URLSession
+    private let defaults: UserDefaults
     private var stagedAppURL: URL?            // unzipped, verified bundle waiting to be swapped in
 
     // Production: the public repo's GitHub API base. Tests inject a stub origin/session.
     private init() {
         self.apiBase = UpdateManager.defaultAPIBase
         self.session = .shared
+        self.defaults = .standard
     }
 
-    /// Test seam — inject a stub GitHub-API base + session so the check can be exercised hermetically.
-    init(apiBase: URL, session: URLSession = .shared) {
+    /// Test seam — inject a stub GitHub-API base + session (+ defaults) so the check can be
+    /// exercised hermetically.
+    init(apiBase: URL, session: URLSession = .shared, defaults: UserDefaults = .standard) {
         self.apiBase = apiBase
         self.session = session
+        self.defaults = defaults
     }
 
     /// The public repo that hosts releases (per the release/update contract).
@@ -76,6 +80,15 @@ final class UpdateManager: ObservableObject {
     static let defaultAPIBase = URL(string: "https://api.github.com/repos/\(repoSlug)")!
     /// GitHub's API requires a User-Agent on every request.
     static let userAgent = "Shadowtype-Updater"
+
+    /// Persisted across launches: a mandatory (minBuild-forced) update was detected but not yet
+    /// installed. AppDelegate reads `hasPendingMandatoryUpdate` at launch to prompt synchronously
+    /// instead of waiting minutes for the first periodic check. Set/cleared by check() (mandatory vs
+    /// optional/up-to-date) and cleared by installAndRelaunch() once the swap is handed off.
+    static let mandatoryPendingKey = "shadowtype.update.mandatoryPending"
+    static var hasPendingMandatoryUpdate: Bool {
+        UserDefaults.standard.bool(forKey: mandatoryPendingKey)
+    }
 
     // MARK: - Current build
 
@@ -102,12 +115,14 @@ final class UpdateManager: ObservableObject {
                   manifest.build > UpdateManager.currentBuild() else {
                 state = manual ? .upToDate : .idle
                 clearPending()
+                defaults.set(false, forKey: Self.mandatoryPendingKey)
                 return nil
             }
             // A newer build exists — but DON'T reveal the menu/"install" affordance yet: it isn't
             // installable until downloadAndStage succeeds (post .shadowtypeUpdateAvailable there).
             pendingManifest = manifest
             state = .available(manifest)
+            defaults.set(isMandatory(manifest), forKey: Self.mandatoryPendingKey)
             return manifest
         } catch {
             state = manual ? .failed(Self.message(for: error)) : .idle
@@ -341,6 +356,9 @@ final class UpdateManager: ObservableObject {
             // can't break out of quoting or be re-evaluated by the shell.
             p.arguments = [script, String(ProcessInfo.processInfo.processIdentifier), staged.path, installPath]
             try p.run()              // detached; survives our termination
+            // The swap is handed off — the mandatory update is no longer pending. (If the swap
+            // somehow fails post-termination, the next launch check re-sets the flag.)
+            defaults.set(false, forKey: Self.mandatoryPendingKey)
             NSApp.terminate(nil)
         } catch {
             state = .failed(Self.message(for: error))

--- a/Tests/ShadowtypeTests/BundleIDValidatorTests.swift
+++ b/Tests/ShadowtypeTests/BundleIDValidatorTests.swift
@@ -1,0 +1,40 @@
+// BundleIDValidator — pure shape check behind the Instructions pane's "Add override" field.
+// Hermetic: no UI, no UserDefaults.
+import XCTest
+@testable import Shadowtype
+
+final class BundleIDValidatorTests: XCTestCase {
+
+    func testTypicalBundleIdsAreValid() {
+        XCTAssertTrue(BundleIDValidator.isValid("com.apple.mail"))
+        XCTAssertTrue(BundleIDValidator.isValid("com.tinyspeck.slackmacgap"))
+        XCTAssertTrue(BundleIDValidator.isValid("notion.id"))                  // 2 components is enough
+        XCTAssertTrue(BundleIDValidator.isValid("com.apple.dt.Xcode"))         // mixed case OK
+        XCTAssertTrue(BundleIDValidator.isValid("org.mozilla.firefox-nightly")) // hyphens OK
+        XCTAssertTrue(BundleIDValidator.isValid("com.2do.mac"))                // digit-leading part OK
+    }
+
+    func testWhitespaceIsTrimmedBeforeValidation() {
+        XCTAssertTrue(BundleIDValidator.isValid("  com.apple.mail \n"))
+    }
+
+    func testSingleComponentIsInvalid() {
+        XCTAssertFalse(BundleIDValidator.isValid("Slack"))
+        XCTAssertFalse(BundleIDValidator.isValid("mail"))
+    }
+
+    func testEmptyAndDotEdgeCasesAreInvalid() {
+        XCTAssertFalse(BundleIDValidator.isValid(""))
+        XCTAssertFalse(BundleIDValidator.isValid("."))
+        XCTAssertFalse(BundleIDValidator.isValid("com."))          // empty trailing component
+        XCTAssertFalse(BundleIDValidator.isValid(".apple"))        // empty leading component
+        XCTAssertFalse(BundleIDValidator.isValid("com..apple"))    // empty middle component
+    }
+
+    func testIllegalCharactersAreInvalid() {
+        XCTAssertFalse(BundleIDValidator.isValid("com.apple mail"))     // inner space
+        XCTAssertFalse(BundleIDValidator.isValid("com.apple.mail!"))    // punctuation
+        XCTAssertFalse(BundleIDValidator.isValid("com.apple.mail_app")) // underscore not allowed
+        XCTAssertFalse(BundleIDValidator.isValid("com.苹果.mail"))       // non-ASCII rejected
+    }
+}

--- a/Tests/ShadowtypeTests/CotabbyGrabsTests.swift
+++ b/Tests/ShadowtypeTests/CotabbyGrabsTests.swift
@@ -3,6 +3,7 @@
 // flicker gate, prompt section budget, RTL detection, insertion strategy, insertion safety, and the
 // inference engine router scaffold. No AX/llama/AppKit runtime needed — runs under `swift test`.
 import XCTest
+import AppKit
 import CoreGraphics
 @testable import Shadowtype
 
@@ -29,6 +30,19 @@ final class CotabbyGrabsTests: XCTestCase {
         _ = s.stabilizedCaretHeight(18, focusSessionKey: 7)
         XCTAssertEqual(s.stabilizedCaretHeight(0, focusSessionKey: 7), 0)     // a bad poll can't pin the min to 0
         XCTAssertEqual(s.stabilizedCaretHeight(18, focusSessionKey: 7), 18)
+    }
+
+    func testStabilizerIgnoresImplausiblySmallReadings() {
+        // Plausibility floor: a sub-8pt caret height is AX noise (collapsed rect mid-relayout) — it
+        // passes through unchanged and must NOT lower the session minimum.
+        var s = GhostFontSizeStabilizer()
+        XCTAssertEqual(s.stabilizedCaretHeight(18, focusSessionKey: 9), 18)
+        XCTAssertEqual(s.stabilizedCaretHeight(5, focusSessionKey: 9), 5)     // noise passes through…
+        XCTAssertEqual(s.stabilizedCaretHeight(40, focusSessionKey: 9), 18)   // …but the min held at 18
+        // Exactly at the floor is a plausible tiny line and DOES participate.
+        XCTAssertEqual(s.stabilizedCaretHeight(GhostFontSizeStabilizer.minPlausibleCaretHeight,
+                                               focusSessionKey: 9), 8)
+        XCTAssertEqual(s.stabilizedCaretHeight(18, focusSessionKey: 9), 8)
     }
 
     // MARK: - #2 OverlayStabilityGate
@@ -181,6 +195,34 @@ final class CotabbyGrabsTests: XCTestCase {
             totalChars: 200)
         XCTAssertTrue(p.hasSuffix("Text:\nmy real sentence so far"))   // caret text never starved
         XCTAssertLessThanOrEqual(p.count, 260)                         // budget + framing overhead
+    }
+
+    // MARK: - OverlayRenderer pure geometry/colors (RTL clamp + appearance-adaptive palette)
+
+    func testRTLOriginClampsToScreenLeftEdge() {
+        // Right edge anchored at the caret when it fits…
+        XCTAssertEqual(OverlayRenderer.rtlOriginX(caretMinX: 500, width: 120, screenMinX: 0), 380)
+        // …clamped to the screen's minX when the panel would slide off the left bezel.
+        XCTAssertEqual(OverlayRenderer.rtlOriginX(caretMinX: 80, width: 120, screenMinX: 0), 0)
+        // Multi-monitor: a screen left of the main one has a negative minX — clamp to THAT edge.
+        XCTAssertEqual(OverlayRenderer.rtlOriginX(caretMinX: -1400, width: 200, screenMinX: -1440), -1440)
+    }
+
+    func testAdaptiveOverlayColors() {
+        // Light-mode values are exactly the historical hardcoded ones (no visual change for light users).
+        XCTAssertEqual(OverlayRenderer.ghostTextColor(dark: false),
+                       NSColor(white: 0.55, alpha: 0.6))
+        XCTAssertEqual(OverlayRenderer.hintBackgroundColor(dark: false), NSColor(white: 0.5, alpha: 0.10))
+        XCTAssertEqual(OverlayRenderer.hintBorderColor(dark: false), NSColor(white: 0.5, alpha: 0.38))
+        XCTAssertEqual(OverlayRenderer.hintLabelColor(dark: false), NSColor(white: 0.42, alpha: 0.95))
+        // Dark variants are LIGHTER (legible on dark backgrounds) at comparable alpha.
+        XCTAssertGreaterThan(OverlayRenderer.ghostTextColor(dark: true).whiteComponent,
+                             OverlayRenderer.ghostTextColor(dark: false).whiteComponent)
+        XCTAssertEqual(OverlayRenderer.ghostTextColor(dark: true).alphaComponent, 0.6)
+        XCTAssertGreaterThan(OverlayRenderer.hintLabelColor(dark: true).whiteComponent,
+                             OverlayRenderer.hintLabelColor(dark: false).whiteComponent)
+        XCTAssertGreaterThan(OverlayRenderer.hintBorderColor(dark: true).whiteComponent,
+                             OverlayRenderer.hintBorderColor(dark: false).whiteComponent)
     }
 
     // MARK: - #11 TextDirectionDetector

--- a/Tests/ShadowtypeTests/EmojiCompletionTests.swift
+++ b/Tests/ShadowtypeTests/EmojiCompletionTests.swift
@@ -29,6 +29,24 @@ final class EmojiCompletionTests: XCTestCase {
         XCTAssertEqual(emoji.currentQuery(prefix: ":smile: then :joy"), "joy")
     }
 
+    // The colon must start a token (start of prefix or after whitespace) — mid-text colons like
+    // times, ratios, and "label: value" must not arm the emoji ghost.
+    func testColonMidTokenDoesNotTrigger() {
+        XCTAssertNil(emoji.currentQuery(prefix: "meeting at 3:smile"))
+        XCTAssertNil(emoji.currentQuery(prefix: "ratio is 1:1"))
+        XCTAssertNil(emoji.currentQuery(prefix: "see https://example"))
+        XCTAssertNil(emoji.currentQuery(prefix: "key:value"))
+        XCTAssertFalse(emoji.isTrigger(prefix: "meeting at 3:smile"))
+        XCTAssertTrue(emoji.matches(prefix: "meeting at 3:smile", limit: 5).isEmpty)
+    }
+
+    func testColonAtStartOrAfterWhitespaceTriggers() {
+        XCTAssertEqual(emoji.currentQuery(prefix: ":smile"), "smile")
+        XCTAssertEqual(emoji.currentQuery(prefix: "hello :smile"), "smile")
+        XCTAssertEqual(emoji.currentQuery(prefix: "line one\n:tada"), "tada")
+        XCTAssertEqual(emoji.currentQuery(prefix: "tabbed\t:fire"), "fire")
+    }
+
     // MARK: - isTrigger
 
     func testIsTrigger() {

--- a/Tests/ShadowtypeTests/HFResolverTests.swift
+++ b/Tests/ShadowtypeTests/HFResolverTests.swift
@@ -124,3 +124,46 @@ final class DiagRedactionTests: XCTestCase {
                        "non-secret strings must round-trip unchanged")
     }
 }
+
+// MARK: - Import-picker helpers (sort + default selection)
+
+extension HFResolverTests {
+    private func sib(_ name: String, _ size: Int64?) -> HFResolver.Sibling {
+        HFResolver.Sibling(filename: name, sizeBytes: size,
+                           downloadURL: URL(string: "https://huggingface.co/o/r/resolve/main/\(name)")!)
+    }
+
+    func testSortedBySizeAscending() {
+        let sorted = HFResolver.sortedBySizeAscending([
+            sib("big.Q8_0.gguf", 8_000), sib("small.Q2_K.gguf", 2_000), sib("mid.Q4_K_M.gguf", 4_000),
+        ])
+        XCTAssertEqual(sorted.map(\.filename),
+                       ["small.Q2_K.gguf", "mid.Q4_K_M.gguf", "big.Q8_0.gguf"])
+    }
+
+    func testSortedBySizeUnknownSizesSinkToBottomAndOrderByName() {
+        let sorted = HFResolver.sortedBySizeAscending([
+            sib("z-unknown.gguf", nil), sib("a-unknown.gguf", nil), sib("known.gguf", 1_000),
+        ])
+        XCTAssertEqual(sorted.map(\.filename),
+                       ["known.gguf", "a-unknown.gguf", "z-unknown.gguf"])
+    }
+
+    func testSortedBySizeTiesBreakByFilename() {
+        let sorted = HFResolver.sortedBySizeAscending([sib("b.gguf", 100), sib("a.gguf", 100)])
+        XCTAssertEqual(sorted.map(\.filename), ["a.gguf", "b.gguf"])
+    }
+
+    func testPreferredImportFilePicksQ4KMCaseInsensitive() {
+        let list = [sib("model.Q2_K.gguf", 1), sib("model.q4_k_m.gguf", 2), sib("model.Q8_0.gguf", 3)]
+        XCTAssertEqual(HFResolver.preferredImportFile(in: list)?.filename, "model.q4_k_m.gguf")
+        let upper = [sib("model.Q2_K.gguf", 1), sib("Model.Q4_K_M.gguf", 2)]
+        XCTAssertEqual(HFResolver.preferredImportFile(in: upper)?.filename, "Model.Q4_K_M.gguf")
+    }
+
+    func testPreferredImportFileFallsBackToFirstWhenNoQ4KM() {
+        let list = [sib("model.Q2_K.gguf", 1), sib("model.Q8_0.gguf", 3)]
+        XCTAssertEqual(HFResolver.preferredImportFile(in: list)?.filename, "model.Q2_K.gguf")
+        XCTAssertNil(HFResolver.preferredImportFile(in: []))
+    }
+}

--- a/Tests/ShadowtypeTests/LocalAPIServerTests.swift
+++ b/Tests/ShadowtypeTests/LocalAPIServerTests.swift
@@ -1,4 +1,5 @@
-// LocalAPIServerTests — pure coverage for the Bearer-auth constant-time compare. The TCP transport
+// LocalAPIServerTests — coverage for the all-ports-busy failure surface and the Bearer-auth
+// constant-time compare. The TCP transport
 // requires a Bearer token; comparing it with `==`/`!=` would short-circuit on the first mismatching
 // byte and leak the key prefix-by-prefix via response timing to a local process that can reach
 // 127.0.0.1 but can't read the Keychain. These lock the helper's correctness (timing is not asserted
@@ -7,6 +8,47 @@ import XCTest
 @testable import Shadowtype
 
 final class LocalAPIServerTests: XCTestCase {
+
+    // MARK: - Failure surfacing
+
+    func testAllPortsBusyMessageIsHumanReadable() {
+        XCTAssertEqual(LocalAPIServer.allPortsBusyMessage, "Ports 5666\u{2013}5670 are all in use")
+    }
+
+    // Occupy every candidate port, then start(): must return nil, set the human-readable
+    // lastError, and leave the server fully stopped (no isRunning, no boundPort).
+    func testStartAllPortsBusySetsLastErrorAndStaysStopped() {
+        var blockers: [Int32] = []
+        defer { for fd in blockers { close(fd) } }
+        for port in LocalAPIServer.portCandidates {
+            let fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)
+            guard fd >= 0 else { continue }
+            var yes: Int32 = 1
+            setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size))
+            var addr = sockaddr_in()
+            addr.sin_family = sa_family_t(AF_INET)
+            addr.sin_port = in_port_t(UInt16(port).bigEndian)
+            addr.sin_addr.s_addr = in_addr_t(0x7F000001).bigEndian
+            let bound = withUnsafePointer(to: &addr) { ptr -> Int32 in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                    Darwin.bind(fd, sa, socklen_t(MemoryLayout<sockaddr_in>.size))
+                }
+            }
+            // A port already busy from another process is busy from start()'s view too — either
+            // way every candidate ends up occupied. Keep only the fds we actually bound.
+            if bound == 0, Darwin.listen(fd, 1) == 0 { blockers.append(fd) } else { close(fd) }
+        }
+
+        // No stop() needed: the failed start() must leave nothing running (that's the assertion) —
+        // and stop() would unlink the UDS path of a live Shadowtype instance on this machine.
+        let server = LocalAPIServer()
+        XCTAssertNil(server.start())
+        XCTAssertEqual(server.lastError, LocalAPIServer.allPortsBusyMessage)
+        XCTAssertFalse(server.isRunning)
+        XCTAssertNil(server.boundPort)
+    }
+
+    // MARK: - constantTimeEquals
 
     func testConstantTimeEqualsMatches() {
         XCTAssertTrue(LocalAPIServer.constantTimeEquals("", ""))

--- a/Tests/ShadowtypeTests/M2LoopTests.swift
+++ b/Tests/ShadowtypeTests/M2LoopTests.swift
@@ -270,7 +270,22 @@ final class M2LoopTests: XCTestCase {
     }
 
     func testSanitizerRemovesMarkdownEmphasis() {
-        XCTAssertEqual(CompletionCoordinator.sanitizedSuggestion("**bold** and `code`"), "bold and code")
+        // `**` always stripped; the BALANCED backtick pair is inline code and survives.
+        XCTAssertEqual(CompletionCoordinator.sanitizedSuggestion("**bold** and `code`"), "bold and `code`")
+    }
+
+    func testSanitizerBacktickPairing() {
+        // Balanced pairs = inline code the user plausibly wants — kept verbatim.
+        XCTAssertEqual(CompletionCoordinator.sanitizedSuggestion("run `make test` to verify"),
+                       "run `make test` to verify")
+        XCTAssertEqual(CompletionCoordinator.sanitizedSuggestion("`a` and `b`"), "`a` and `b`")
+        // Odd count = a stray markup tick (or a pair still streaming in) — stripped.
+        XCTAssertEqual(CompletionCoordinator.sanitizedSuggestion("stray ` tick"), "stray  tick")
+        XCTAssertEqual(CompletionCoordinator.sanitizedSuggestion("run `make test` plus ` stray"),
+                       "run make test plus  stray")
+        // Idempotent either way (the post-accept remainder re-render runs the sanitizer again).
+        let balanced = CompletionCoordinator.sanitizedSuggestion("keep `this`")
+        XCTAssertEqual(CompletionCoordinator.sanitizedSuggestion(balanced), balanced)
     }
 
     func testSanitizerIsIdempotent() {

--- a/Tests/ShadowtypeTests/ModelManagerDiskPreflightTests.swift
+++ b/Tests/ShadowtypeTests/ModelManagerDiskPreflightTests.swift
@@ -1,0 +1,42 @@
+// ModelManager.checkDiskSpace — pure disk-space preflight comparison + human-facing message.
+// Hermetic: synthetic byte counts, no real volume queries.
+import XCTest
+@testable import Shadowtype
+
+final class ModelManagerDiskPreflightTests: XCTestCase {
+
+    func testEnoughSpaceDoesNotThrow() {
+        XCTAssertNoThrow(try ModelManager.checkDiskSpace(neededBytes: 1_000_000_000,
+                                                         availableBytes: 2_000_000_000))
+    }
+
+    func testExactFitDoesNotThrow() {
+        XCTAssertNoThrow(try ModelManager.checkDiskSpace(neededBytes: 5_000_000_000,
+                                                         availableBytes: 5_000_000_000))
+    }
+
+    func testInsufficientSpaceThrowsWithGBFigures() {
+        XCTAssertThrowsError(try ModelManager.checkDiskSpace(neededBytes: 5_000_000_000,
+                                                             availableBytes: 1_200_000_000)) { error in
+            guard case let ModelManagerError.insufficientDiskSpace(neededGB, availableGB) = error else {
+                XCTFail("expected .insufficientDiskSpace, got \(error)"); return
+            }
+            XCTAssertEqual(neededGB, 5.0, accuracy: 0.01)
+            XCTAssertEqual(availableGB, 1.2, accuracy: 0.01)
+        }
+    }
+
+    func testInsufficientSpaceMessageIsActionable() {
+        do {
+            try ModelManager.checkDiskSpace(neededBytes: 5_000_000_000, availableBytes: 1_200_000_000)
+            XCTFail("expected throw")
+        } catch {
+            let msg = (error as? LocalizedError)?.errorDescription ?? ""
+            XCTAssertEqual(msg, "Not enough disk space (need 5.0 GB, 1.2 GB available).")
+        }
+    }
+
+    func testZeroAvailableThrows() {
+        XCTAssertThrowsError(try ModelManager.checkDiskSpace(neededBytes: 1, availableBytes: 0))
+    }
+}

--- a/Tests/ShadowtypeTests/OnboardingResumeTests.swift
+++ b/Tests/ShadowtypeTests/OnboardingResumeTests.swift
@@ -1,0 +1,25 @@
+// Onboarding resume — the pure step-persistence logic behind "close mid-flow, resume where you
+// left off" (OnboardingWindowController.stepKey). The flow has 8 steps (welcome=0 … done=7).
+import XCTest
+@testable import Shadowtype
+
+final class OnboardingResumeTests: XCTestCase {
+    private let stepCount = 8   // OBStep.allCases.count (welcome … done)
+
+    func testClampedResumeStepPassesValidValuesThrough() {
+        XCTAssertEqual(OnboardingWindowController.clampedResumeStep(0, stepCount: stepCount), 0)
+        XCTAssertEqual(OnboardingWindowController.clampedResumeStep(4, stepCount: stepCount), 4)
+        XCTAssertEqual(OnboardingWindowController.clampedResumeStep(7, stepCount: stepCount), 7)
+    }
+
+    func testClampedResumeStepClampsOutOfRangeValues() {
+        XCTAssertEqual(OnboardingWindowController.clampedResumeStep(-3, stepCount: stepCount), 0)
+        XCTAssertEqual(OnboardingWindowController.clampedResumeStep(99, stepCount: stepCount), 7)
+    }
+
+    func testCloseCompletesOnboardingOnlyOnFinalStep() {
+        XCTAssertFalse(OnboardingWindowController.closeCompletesOnboarding(stepRaw: 0))
+        XCTAssertFalse(OnboardingWindowController.closeCompletesOnboarding(stepRaw: 6))
+        XCTAssertTrue(OnboardingWindowController.closeCompletesOnboarding(stepRaw: 7))
+    }
+}

--- a/Tests/ShadowtypeTests/UpdateManagerTests.swift
+++ b/Tests/ShadowtypeTests/UpdateManagerTests.swift
@@ -137,6 +137,61 @@ final class UpdateManagerTests: XCTestCase {
         XCTAssertFalse(mgr.isMandatory(optional))
     }
 
+    // MARK: - Mandatory-pending flag (persisted across launches)
+
+    func testCheckSetsMandatoryPendingForMinBuildForcedUpdate() async {
+        let suite = "shadowtype.tests.updatemgr.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let assetURL = "https://github.test/dl/latest.json"
+        StubProtocol.routes = [
+            "/repos/dario-valles/shadowtype/releases/latest": singleReleaseJSON(assetURL: assetURL),
+            "/dl/latest.json": sampleManifestJSON(build: UpdateManager.currentBuild() + 10,
+                                                  minBuild: UpdateManager.currentBuild() + 10),
+        ]
+        let mgr = UpdateManager(apiBase: apiBase, session: Self.stubSession(), defaults: defaults)
+        _ = await mgr.check(channel: .stable, manual: true)
+        XCTAssertTrue(defaults.bool(forKey: UpdateManager.mandatoryPendingKey))
+
+        // An optional newer build (minBuild already satisfied) clears the flag.
+        StubProtocol.routes["/dl/latest.json"] =
+            sampleManifestJSON(build: UpdateManager.currentBuild() + 10, minBuild: 0)
+        _ = await mgr.check(channel: .stable, manual: true)
+        XCTAssertFalse(defaults.bool(forKey: UpdateManager.mandatoryPendingKey))
+    }
+
+    func testCheckClearsMandatoryPendingWhenUpToDate() async {
+        let suite = "shadowtype.tests.updatemgr.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(true, forKey: UpdateManager.mandatoryPendingKey)
+
+        let assetURL = "https://github.test/dl/latest.json"
+        StubProtocol.routes = [
+            "/repos/dario-valles/shadowtype/releases/latest": singleReleaseJSON(assetURL: assetURL),
+            "/dl/latest.json": sampleManifestJSON(build: 0),   // never newer → up to date
+        ]
+        let mgr = UpdateManager(apiBase: apiBase, session: Self.stubSession(), defaults: defaults)
+        _ = await mgr.check(channel: .stable, manual: true)
+        XCTAssertFalse(defaults.bool(forKey: UpdateManager.mandatoryPendingKey))
+    }
+
+    // MARK: - Failure state carries a human-readable message
+
+    func testFailedDownloadStateCarriesMessage() async {
+        let mgr = UpdateManager(apiBase: apiBase, session: Self.stubSession())
+        // Non-https URL is rejected before any network I/O.
+        let manifest = UpdateManifest(version: "9.9.9", build: UpdateManager.currentBuild() + 1,
+                                      channel: "stable", url: "ftp://github.test/x.zip",
+                                      sha256: String(repeating: "a", count: 64), minBuild: 0, notes: "")
+        await mgr.downloadAndStage(manifest)
+        guard case .failed(let message) = mgr.state else {
+            return XCTFail("expected .failed, got \(mgr.state)")
+        }
+        XCTAssertFalse(message.isEmpty)
+    }
+
     // MARK: - TCC continuity guard (isSignatureContinuous)
 
     func testSignatureContinuityAllowsSameIdentity() {


### PR DESCRIPTION
## Summary

Full UX audit of the app (4 parallel reviewers over onboarding/lifecycle, settings/models, ghost overlay, rewrite/hotkeys) followed by a fix batch covering ~35 confirmed findings. Builds clean; 575 tests pass (29 new).

## Highlights by surface

**Onboarding & lifecycle**
- First permission press shows only the system dialog (Settings opens only on retry after a prior denial)
- Model step can no longer be skipped silently — Continue gated on install, explicit "Skip for now" states the consequence; rail jumps respect the same gate
- Mid-flow close persists the step and resumes there next launch
- LaunchAtLogin failures, AX-nudge dismissal stakes, stale "/100" counter, status-menu title sync, mandatory-update launch prompt

**Settings & models**
- Active-model pill shows real state; download errors surfaced with reason (incl. disk-space preflight); determinate progress bar with %
- Mid-download switch race closed; removing the active model confirms + falls back
- HF import: real cancel, size-sorted file list with Q4_K_M auto-pick
- Local API: Starting… state + failure reason; key-rotation warning separated from copy toasts
- Screen-context OCR asks before enabling after a Screen Recording grant (was silent flip — privacy surprise)
- Bundle-ID validation, wipe-profile confirm, Instruct pill, updater retry button

**Ghost overlay**
- Dark-mode-adaptive Tab keycap + ghost color (light values unchanged)
- IME composition clears/suppresses the ghost (Cocoa hosts; Electron documented limitation)
- RTL left-edge clamp, caret-height plausibility floor, wider paste-restore window for Electron, badge below system status bar, balanced-backtick preservation

**Rewrite & hotkeys**
- Rewrite shortcut configurable (⌥⌘K default / ⌃⌘K / ⌥⌘J) — ⌥⌘K collides with Apple Writing Tools on macOS 15+
- ⌘R passes through to the browser during web rewrite sessions (was a dead key)
- Specific toasts for model-not-ready and rewrite-timeout; HUD dismisses on Spaces switch
- Emoji shortcode no longer fires mid-token (`3:smile`, `key:value`)

## Deliberately unchanged
- FocusCapabilityFlickerGate release threshold kept (tests lock it; comment fixed instead)
- 3-layer ghost dedup, mid-line default OFF, re-fire count cap (intentional designs)

## Test plan
- [x] `swift build` (debug + release) clean
- [x] `swift test` — 575 pass, 0 fail (29 new: emoji guard, bundle-ID validator, disk preflight, onboarding resume, update mandatory-pending, overlay colors/RTL/stabilizer, backtick pairing, local API port-busy)
- [ ] Manual smoke: onboarding flow, model download with progress, dark-mode ghost, rewrite chord change (needs live app — TCC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)