### PR TITLE
Core overhaul: prompt/KV path, confidence gating, context cost, model integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ spell-check: invisible until useful, never in the way.
 - **Local OpenAI-compatible API + MCP bridge** — Shadowtype exposes a local HTTP API and ships an
   MCP bridge so editors and agents (Claude Code, Cursor, any MCP host) can use the on-device model.
 - **Multi-model catalog** — a curated set of GGUF models with RAM-fit gating, plus bring-your-own
-  GGUF import. Models are downloaded on demand and SHA-256-verified; none are bundled.
+  GGUF import. Models are downloaded on demand and checked against the publisher's SHA-256 when one
+  is published; none are bundled.
 - **Context-aware** — optional local screen OCR, clipboard context, and learned typing style feed
   the model. Per-app / per-domain enable/disable. Password and secure fields are never read.
 

--- a/Sources/Shadowtype/AppDelegate.swift
+++ b/Sources/Shadowtype/AppDelegate.swift
@@ -27,6 +27,63 @@ private final class RewriteActionPayload: NSObject {
     }
 }
 
+// Adaptive back-off for an always-on background app. Nothing used to consult thermalState or Low
+// Power Mode, so Shadowtype ran the identical GPU inference on every typing pause whether the Mac was
+// cool on wall power or already thermally throttled on battery — the difference between "invisible"
+// and "my fan is on and my battery is gone". This maps the two free ProcessInfo signals onto the
+// three knobs AppDelegate already pushes (coordinator.debounce / coordinator.maxTokens /
+// engine.maxContextTokens): fire less often, generate less, prefill less.
+//
+// Pure + static so the mapping is unit-testable without a hot Mac.
+struct PowerPolicy {
+    /// The knobs the policy adapts, in the units AppDelegate pushes them.
+    struct Settings: Equatable {
+        var debounce: TimeInterval
+        var maxTokens: Int
+        var maxContextTokens: Int
+    }
+
+    // `nominal` (not `none`) so a `.none` at a call site can never be read as `Optional.none`.
+    enum Tier { case nominal, moderate, heavy }
+
+    /// `.fair` is the steady state of any laptop doing real work, so treating it as pressure would
+    /// mean throttling almost always; back off from `.serious` up. Low Power Mode is an explicit
+    /// user request to spend less energy, so it earns the same treatment as `.serious` — and it
+    /// never softens `.critical`.
+    static func tier(thermalState: ProcessInfo.ThermalState, lowPower: Bool) -> Tier {
+        switch thermalState {
+        case .critical: return .heavy
+        case .serious:  return .moderate
+        default:        return lowPower ? .moderate : .nominal
+        }
+    }
+
+    /// Adaptation may only make things LIGHTER: the debounce can only grow, tokens/context can only
+    /// shrink, so the user's own settings stay the ceiling. Suggestions are never switched off — a
+    /// silently dead product is worse than a slower one.
+    static func adjust(_ base: Settings,
+                       thermalState: ProcessInfo.ThermalState,
+                       lowPower: Bool) -> Settings {
+        switch tier(thermalState: thermalState, lowPower: lowPower) {
+        case .nominal:
+            return base
+        case .moderate:
+            return lighter(base, debounceScale: 2, debounceCap: 0.6, maxTokens: 12, contextTokens: 1024)
+        case .heavy:
+            return lighter(base, debounceScale: 3, debounceCap: 1.0, maxTokens: 8, contextTokens: 512)
+        }
+    }
+
+    // The caps are absolute, the debounce stretch is relative — but a user who already asked for a
+    // long delay must not be sped up by the cap, hence the max() against the configured value.
+    private static func lighter(_ base: Settings, debounceScale: Double, debounceCap: TimeInterval,
+                                maxTokens: Int, contextTokens: Int) -> Settings {
+        Settings(debounce: max(base.debounce, min(debounceCap, base.debounce * debounceScale)),
+                 maxTokens: min(base.maxTokens, maxTokens),
+                 maxContextTokens: min(base.maxContextTokens, contextTokens))
+    }
+}
+
 final class AppDelegate: NSObject, NSApplicationDelegate {
     // P0
     let engine = InferenceEngine()
@@ -68,6 +125,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let screenContext = ScreenContextProvider()
     private var ocrSettingObserver: NSObjectProtocol?
     private var appSettingsObserver: NSObjectProtocol?
+    // Thermal pressure / Low Power Mode (see PowerPolicy). Both signals only ever loosen the live
+    // knobs; the stored settings they are derived from are untouched.
+    private var thermalObserver: NSObjectProtocol?
+    private var powerModeObserver: NSObjectProtocol?
     // Per-app "we can't read this app" banner (Google Docs et al). Coordinator posts the trigger; this
     // owns the floating panel + persisted "don't show again" state (AXNudgeStore).
     private let axNudge = AccessibilityNudgeController()
@@ -373,6 +434,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.updateTabDisableForFrontmost()
         }
 
+        // Thermal pressure / Low Power Mode: re-apply the knobs so a hot or battery-saving Mac gets a
+        // longer pause and a shorter generation, and gets its full settings back when it recovers.
+        // Both notifications can be delivered on any thread; queue: .main because every knob they
+        // touch is main-thread-owned (as with the settings observers above).
+        thermalObserver = NotificationCenter.default.addObserver(
+            forName: ProcessInfo.thermalStateDidChangeNotification, object: nil, queue: .main
+        ) { [weak self] _ in self?.applyPowerPolicy() }
+        powerModeObserver = NotificationCenter.default.addObserver(
+            forName: .NSProcessInfoPowerStateDidChange, object: nil, queue: .main
+        ) { [weak self] _ in self?.applyPowerPolicy() }
+
         // FR-CE-3: the Context length picker writes CompletionLength.defaultsKey then posts this.
         lengthObserver = NotificationCenter.default.addObserver(
             forName: .shadowtypeCompletionLengthChanged, object: nil, queue: .main
@@ -517,10 +589,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             UserDefaults.standard.object(forKey: "styleProfileEnabled") == nil
             ? true
             : UserDefaults.standard.bool(forKey: "styleProfileEnabled")
-        // General → "Suggestion trigger delay". Default 50 ms when unset; clamp to the slider range.
-        // This is the adaptive-pause FLOOR (see CompletionCoordinator.adaptiveDelay).
-        let delayMs = UserDefaults.standard.object(forKey: "shadowtype.triggerDelayMs") as? Double ?? 50
-        coordinator.debounce = max(0.04, min(0.4, delayMs / 1000))
+        // General → "Suggestion trigger delay" + Context → "Context window size" + the completion-length
+        // preset's token ceiling all land through the thermal/Low-Power policy (see applyPowerPolicy).
+        applyPowerPolicy()
         // General → "Aggressiveness": scales the confirmed-pause threshold on top of the delay floor.
         coordinator.pauseMultiplier = Aggressiveness.current().pauseMultiplier
         // General → "Show active-field indicator" (default ON when unset). Re-evaluate the badge live.
@@ -547,17 +618,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Personalization → "strength" (0...3, default 3 when unset). 0 disables the style hint.
         coordinator.personalizationStrength =
             (UserDefaults.standard.object(forKey: "shadowtype.personalizationStrength") as? Int) ?? 3
-        // Context → "Context window size" (tokens; default 1024 when unset). Drives the engine prefix cap
-        // AND the coordinator's prompt byte budget — THE TWO MUST STAY IN SYNC, which is why they are set
-        // together here (this is the only place that knows the setting). InferenceEngine.generate()
-        // front-trims the tokenized prompt to this cap, and the front of the prompt is the `Context:`
-        // header plus every context block, so a budget bigger than the cap silently throws away the
-        // context we just paid to build. See CompletionCoordinator.promptBudgetBytes.
-        let contextTokens =
-            (UserDefaults.standard.object(forKey: "shadowtype.contextWindowTokens") as? Int) ?? 1024
-        engine.maxContextTokens = contextTokens
-        coordinator.promptCharBudget =
-            CompletionCoordinator.promptBudgetBytes(forContextTokens: contextTokens)
         // Models → "Unload model when idle" (minutes; 0 == Never; default 10 matches the picker). The
         // idle timer reads this.
         idleUnloadMinutes =
@@ -650,10 +710,47 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func applyCompletionLength() {
         let length = CompletionLength.current()
         engine.maxWords = length.maxWords
-        coordinator.maxTokens = length.maxTokens
+        // The preset's token ceiling reaches coordinator.maxTokens through applyPowerPolicy, which may
+        // cap it further under thermal pressure / Low Power Mode.
+        applyPowerPolicy()
         // Longer presets end on a sentence boundary after their grace word-count instead of truncating
         // at the hard maxWords cap (short/medium pass 0 = legacy word-cap-only behaviour).
         engine.stopAtSentenceAfterWords = length.sentenceStopAfterWords
+    }
+
+    /// The user's own settings, read fresh from the store. This is the ceiling PowerPolicy adapts DOWN
+    /// from — deliberately re-derived on every apply instead of snapshotted before a throttle, so a
+    /// setting the user changes WHILE throttled is not clobbered when the Mac cools down again.
+    private func configuredSettings() -> PowerPolicy.Settings {
+        // General → "Suggestion trigger delay". Default 50 ms when unset; clamp to the slider range.
+        // This is the adaptive-pause FLOOR (see CompletionCoordinator.adaptiveDelay).
+        let delayMs = UserDefaults.standard.object(forKey: "shadowtype.triggerDelayMs") as? Double ?? 50
+        // Context → "Context window size" (tokens; default 1024 when unset).
+        let contextTokens =
+            (UserDefaults.standard.object(forKey: "shadowtype.contextWindowTokens") as? Int) ?? 1024
+        return PowerPolicy.Settings(debounce: max(0.04, min(0.4, delayMs / 1000)),
+                                    maxTokens: CompletionLength.current().maxTokens,
+                                    maxContextTokens: contextTokens)
+    }
+
+    /// Push the configured settings through the thermal / Low Power Mode policy into the live knobs.
+    /// Called from syncToggles, applyCompletionLength, and the two power notifications.
+    private func applyPowerPolicy() {
+        let info = ProcessInfo.processInfo
+        let applied = PowerPolicy.adjust(configuredSettings(),
+                                         thermalState: info.thermalState,
+                                         lowPower: info.isLowPowerModeEnabled)
+        coordinator.debounce = applied.debounce
+        coordinator.maxTokens = applied.maxTokens
+        // The context window drives the engine prefix cap AND the coordinator's prompt byte budget —
+        // THE TWO MUST STAY IN SYNC, which is why they are set together here (this is the only place
+        // that knows the effective value). InferenceEngine.generate() front-trims the tokenized prompt
+        // to this cap, and the front of the prompt is the `Context:` header plus every context block,
+        // so a budget bigger than the cap silently throws away the context we just paid to build. See
+        // CompletionCoordinator.promptBudgetBytes.
+        engine.maxContextTokens = applied.maxContextTokens
+        coordinator.promptCharBudget =
+            CompletionCoordinator.promptBudgetBytes(forContextTokens: applied.maxContextTokens)
     }
 
     // FR-LM-1: download+verify the chosen catalog entry, then swap the active model live on the
@@ -789,7 +886,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let ocrSettingObserver {
             NotificationCenter.default.removeObserver(ocrSettingObserver)
         }
-        for obs in [lengthObserver, selectModelObserver, appSettingsObserver, rewriteHotkeyObserver].compactMap({ $0 }) {
+        for obs in [lengthObserver, selectModelObserver, appSettingsObserver, rewriteHotkeyObserver,
+                    thermalObserver, powerModeObserver].compactMap({ $0 }) {
             NotificationCenter.default.removeObserver(obs)
         }
         idleTimer?.invalidate()

--- a/Sources/Shadowtype/AppDelegate.swift
+++ b/Sources/Shadowtype/AppDelegate.swift
@@ -527,9 +527,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Personalization → "strength" (0...3, default 3 when unset). 0 disables the style hint.
         coordinator.personalizationStrength =
             (UserDefaults.standard.object(forKey: "shadowtype.personalizationStrength") as? Int) ?? 3
-        // Context → "Context window size" (tokens; default 1024 when unset). Drives the engine prefix cap.
-        engine.maxContextTokens =
+        // Context → "Context window size" (tokens; default 1024 when unset). Drives the engine prefix cap
+        // AND the coordinator's prompt byte budget — THE TWO MUST STAY IN SYNC, which is why they are set
+        // together here (this is the only place that knows the setting). InferenceEngine.generate()
+        // front-trims the tokenized prompt to this cap, and the front of the prompt is the `Context:`
+        // header plus every context block, so a budget bigger than the cap silently throws away the
+        // context we just paid to build. See CompletionCoordinator.promptBudgetBytes.
+        let contextTokens =
             (UserDefaults.standard.object(forKey: "shadowtype.contextWindowTokens") as? Int) ?? 1024
+        engine.maxContextTokens = contextTokens
+        coordinator.promptCharBudget =
+            CompletionCoordinator.promptBudgetBytes(forContextTokens: contextTokens)
         // Models → "Unload model when idle" (minutes; 0 == Never; default 10 matches the picker). The
         // idle timer reads this.
         idleUnloadMinutes =

--- a/Sources/Shadowtype/AppDelegate.swift
+++ b/Sources/Shadowtype/AppDelegate.swift
@@ -116,6 +116,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var idleTimer: Timer?
     private var modelIdleUnloaded = false
 
+    // Focus generation whose field we have already warmed (FR-CE-8). Both warm triggers — app activation
+    // and the tracker's own focus-change callback — go through warmFocusIfFocusChanged(), so an app
+    // switch warms exactly once and the per-keystroke kAXValueChanged republishes warm not at all.
+    private var lastWarmedFocusSeq: UInt64?
+
     // Auto-update (UpdateManager): a once-a-day check timer, rescheduled by syncToggles when the
     // "Automatically check for updates" toggle flips. nil when auto-checks are off.
     private var updateTimer: Timer?
@@ -226,7 +231,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self.coordinator.cancel()
             // Let AX focus settle after the activation before reading the caret.
             DispatchQueue.main.async {
-                self.coordinator.warmFocus()
+                self.warmFocusIfFocusChanged()
                 self.refreshBadge()
             }
         }
@@ -248,8 +253,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // A left-click on the badge opens the scoped disable/settings menu (Cotypist parity), rebuilt
         // each click so it reflects the current frontmost app + domain.
         badge.menuProvider = { [weak self] in self?.makeBadgeMenu() ?? NSMenu() }
-        // Re-anchor / hide the active-field badge on every focus change (set before start()).
-        contextTracker.onFocusChange = { [weak self] in self?.refreshBadge() }
+        // Re-anchor / hide the active-field badge on every focus change (set before start()), and warm
+        // the KV cache for the newly focused field. The warm used to hang off
+        // NSWorkspace.didActivateApplicationNotification ALONE, so moving between fields WITHIN an app
+        // (compose box → subject → another compose box) never warmed anything and the first keystroke
+        // there always paid a cold prefill. This callback also fires on kAXValueChanged (i.e. every
+        // keystroke), which is exactly why warmFocusIfFocusChanged() gates on the focus SEQUENCE.
+        contextTracker.onFocusChange = { [weak self] in
+            guard let self else { return }
+            self.refreshBadge()
+            self.warmFocusIfFocusChanged()
+        }
         contextTracker.start()
         inputMonitor.start()
         // Global force-activate hotkey (⌃`): same effect as the menu's "Force suggestions here".
@@ -399,6 +413,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         // todayCount() applies the local-midnight rollover; there is no daily cap (dailyCap is nil).
         statusItem.setWordCount(wordMeter.todayCount())
+
+        // An API/MCP request counts as activity, exactly like a keystroke: it pushes back the
+        // idle-unload window and lazily reloads a model the idle timer already unloaded. Without this
+        // the API could neither keep the model alive nor wake it — once unloaded, every request failed
+        // at the engine.isLoaded guard until the user physically typed somewhere.
+        coordinator.onExternalActivity = { [weak self] in self?.noteActivityAndReloadIfNeeded() }
 
         // M1: local API server. Started here if the user has flipped the toggle on.
         localAPI.coordinator = coordinator
@@ -729,11 +749,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    // Warm the KV cache for the focused field, but only once per focus session (FR-CE-8). Called from the
+    // app-activation observer AND from contextTracker.onFocusChange — the latter is the only signal for a
+    // focus move WITHIN an app, and it also fires on kAXValueChanged (every keystroke), so the sequence
+    // guard is what stops a per-keystroke storm of cold prefills on the inference queue.
+    private func warmFocusIfFocusChanged() {
+        // Also require a resident model: warmFocus() bails on an unloaded engine, and recording the
+        // sequence for a warm that never ran would mark this field warmed for the rest of its focus
+        // session — the launch case, where the model is still loading when focus first resolves.
+        guard enabled, coordinator.isEngineLoaded else { return }
+        let seq = contextTracker.focusChangeSequence
+        guard seq != lastWarmedFocusSeq else { return }
+        lastWarmedFocusSeq = seq
+        coordinator.warmFocus()
+    }
+
     // Unload the resident model after `idleUnloadMinutes` of inactivity (0 == Never). No-op while already
-    // unloaded, mid-reload, or mid-swap (modelReloadInFlight covers both). Main-thread only (the timer
-    // fires on main).
+    // unloaded, mid-reload, mid-swap (modelReloadInFlight covers both), or while an API/MCP request is
+    // decoding — the idle window is measured from keyboard/focus activity plus API requests, but a single
+    // long stream can outlive the window, and unloading under it frees the llama context out from under
+    // the client's own decode. Main-thread only (the timer fires on main).
     private func unloadModelIfIdle() {
         guard idleUnloadMinutes > 0, !modelIdleUnloaded, !modelReloadInFlight,
+              !coordinator.hasInFlightAPIRequests,
               coordinator.isModelLoaded else { return }
         guard Date().timeIntervalSince(lastInputAt) >= Double(idleUnloadMinutes) * 60 else { return }
         coordinator.unloadModel()
@@ -762,7 +800,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         tabSwallow.stop()
         inputMonitor.stop()
         contextTracker.stop()
-        engine.unload()
+        // The engine has no internal locking: every other unload/load is serialized onto the
+        // coordinator's inferenceQueue precisely because freeing the llama context under an in-flight
+        // `llama_decode` is a use-after-free. This used to free it straight on MAIN, so quitting
+        // mid-suggestion was a crash-on-quit. unloadModelAndWait() cancels the running decode, then
+        // performs the unload ON that queue and blocks until it is done (the process is exiting; an
+        // async unload would just lose the race).
+        coordinator.unloadModelAndWait()
     }
 
     // MARK: - Accessibility gate (FR-KC-1)

--- a/Sources/Shadowtype/Autocorrect.swift
+++ b/Sources/Shadowtype/Autocorrect.swift
@@ -8,7 +8,8 @@
 // Bias is the same as TypoGuard's, only flipped in cost: a WRONG correction (silently rewriting a
 // word the user meant) is far worse than NO correction, so every path here is conservative. We only
 // return a fix that is exactly one edit (Damerau-Levenshtein distance 1) from a known lexicon word,
-// and only when that fix is unambiguous (a single confident candidate). Anything short, ALL-CAPS,
+// only when that fix is unambiguous (a single confident candidate), and only when the system
+// dictionary does NOT already recognise the word we are about to rewrite. Anything short, ALL-CAPS,
 // proper-noun-like, or containing digits/symbols is left untouched.
 import Foundation
 
@@ -79,8 +80,13 @@ struct Autocorrect {
         if Autocorrect.isLikelyProperNounOrAcronym(chars) { return nil }
 
         let lower = raw.lowercased()
-        // Already a correct word -> nothing to fix.
-        if lexicon.contains(lower) { return nil }
+        // Already a correct word -> nothing to fix. The lexicon membership test is only a fast path:
+        // it holds a few hundred SINGULAR/base forms, so on its own it happily "corrected" every
+        // regular plural and dozens of ordinary words into a lexicon entry one edit away —
+        // weeks->week, must->just, form->from — i.e. it rewrote text the user had spelled correctly,
+        // the worst failure this engine has. The on-device system dictionary is the authority; this
+        // is the exact gate TypoGuard applies before its own edit-distance signal.
+        if lexicon.contains(lower) || TypoGuard.isRealWord(raw) { return nil }
 
         // Gather every lexicon word exactly one Damerau-Levenshtein edit away. Demand a UNIQUE
         // candidate: if two distinct words are both one edit away we cannot confidently pick, so we

--- a/Sources/Shadowtype/CompletionCoordinator.swift
+++ b/Sources/Shadowtype/CompletionCoordinator.swift
@@ -127,6 +127,19 @@ final class CompletionCoordinator {
     // so the latency-critical generate() never awaits; refreshed by a background Task on each fire.
     private var ocrCache: String?
     private let ocrLock = NSLock()
+    // Dominant language of the CACHED screen context, latched once per CAPTURE rather than re-detected on
+    // every prompt assembly (#10). Re-detecting per fire let a borderline read flip between two fires of
+    // the same typing burst, and that name lands in the `Text (in <Language>):` marker sitting IMMEDIATELY
+    // before the prefix — i.e. a change in the prompt head, i.e. a full cold re-prefill on every flip.
+    // Recomputed only when storeOCRCache accepts a genuinely different capture. Main-thread only.
+    private var ocrCacheLang: NLLanguage?
+    // Text around the caret whose KV warm is waiting on this focus's first OCR capture (#11).
+    // warmFocus() defers the prefill rather than warming a prompt the first real fire will not match;
+    // the capture's completion flushes it. Carries the post-caret text as well as the prefix for the
+    // same reason the deferral exists at all: warming without the `After the cursor:` block the first
+    // real fire WILL assemble diverges the two streams inside the context region and throws the whole
+    // prefill away. Main-thread only.
+    private var pendingWarm: (prefix: String, postCaret: String?)?
 
     // Per-focus OCR capture lifecycle (main-thread only). `.pending` = the capture for this focus is in
     // flight and we have NO context yet, so fire() holds back the first (context-blind) guess until it
@@ -359,6 +372,27 @@ final class CompletionCoordinator {
     // RTL-ness of the current generation's prefix, computed ONCE when the prefix is set (the caret text
     // is fixed for a generation) instead of re-scanning it on every streamed token (#14).
     private var generationRTL = false
+    // Prefix-invariant work hoisted OUT of the per-33 ms render tick (#9). renderSuggestion runs once per
+    // streamed snapshot, and for a fixed `activePrefix` — which is exactly what a generation has, since
+    // the user is paused — none of these can change between ticks, yet each was recomputed every tick:
+    // a fresh NLLanguageRecognizer().processString over the WHOLE prefix, plus an AX caret-rect read and
+    // an AX caret-font read (two IPC round trips a frame). Resolved once in startGeneration next to
+    // generationRTL; nil means "resolve live" (the emoji / correction / shell-history ghosts and the
+    // post-accept remainder re-render, whose caret HAS moved). Cleared by cancel()/clearSuggestion().
+    private var generationCaretRect: CGRect?
+    private var generationFont: NSFont?
+    // The prefix side of the language-drift guard. `.none` = not computed / prefix too short or
+    // ambiguous (the guard then never fires, matching languageDrifts' own conservative bail).
+    private var generationPrefixLang: NLLanguage?
+    // The ONE focus resolution for the current fire() (#9). Every gate in fire() and the render path
+    // reads AX facts from here instead of re-walking the tree. Dropped in cancel(); `currentFocusSnapshot`
+    // additionally refuses to hand back a snapshot whose focus session has since changed, so a stale
+    // snapshot can never cross a focus change.
+    private var focusSnapshot: EditContextTracker.FocusSnapshot?
+    private var currentFocusSnapshot: EditContextTracker.FocusSnapshot? {
+        guard let s = focusSnapshot, s.focusSeq == context.focusChangeSequence else { return nil }
+        return s
+    }
     // Debounces a transient "field briefly reports no editable context" flicker on the same focus
     // session so the ghost doesn't tear down and rebuild (#3).
     private var capabilityGate = FocusCapabilityFlickerGate()
@@ -439,6 +473,12 @@ final class CompletionCoordinator {
         engine.requestCancel()     // cooperative stop between chunks/tokens
         contextRefireCount = 0     // a new keystroke/focus/force re-arms the one context-upgrade re-fire
         generationContextLang = nil
+        // #9: the focus resolution belongs to the superseded fire(). Dropping it here (plus the focus-seq
+        // check in `currentFocusSnapshot`) is what guarantees a stale snapshot can never cross into
+        // another field — cancel() runs on every keystroke, focus change and force-activate.
+        focusSnapshot = nil
+        // #11: a warm prefill deferred behind a capture is for the field we are leaving.
+        pendingWarm = nil
         clearSuggestion()
     }
 
@@ -484,33 +524,82 @@ final class CompletionCoordinator {
                           cancelToken: APIRequestCancelToken,
                           onPiece: @escaping (String) -> Bool,
                           onComplete: @escaping (Result<Void, LocalAPIError>) -> Void) {
+        // Count the request as ACTIVITY before anything else. The idle-unload timer only ever saw
+        // keyboard/focus events, so `unloadModelIfIdle` would free the model out from under a client
+        // that had been streaming for ten minutes, and once unloaded every later request died at the
+        // `engine.isLoaded` guard below — forever, until the user physically typed somewhere. The
+        // in-flight count additionally lets AppDelegate refuse to unload while a decode is running.
+        noteAPIRequestStarted()
         inferenceQueue.async { [weak self] in
             // Review #5: route handlers block on a DispatchSemaphore waiting for onComplete to
             // fire — if we early-return without invoking it (coordinator deallocated during
             // teardown), the HTTP worker hangs forever and leaks the socket. Always call
             // onComplete on EVERY exit path so the route writes a response and closes.
             guard let self else {
+                // No self means the coordinator (and with it the counter nobody can read any more) is
+                // gone; just make sure the waiting route is released.
                 onComplete(.failure(.modelNotLoaded))
                 return
             }
+            defer { self.noteAPIRequestFinished() }
             guard self.engine.isLoaded else { onComplete(.failure(.modelNotLoaded)); return }
             do {
                 try self.engine.generate(prompt: prompt,
                                          maxTokens: maxTokens,
                                          seqID: 1,
                                          params: params,
+                                         contextTokenCap: self.engine.contextWindowTokens,
                                          requiredPrefix: nil,
                                          onToken: { piece in
                                              if cancelToken.isCancelled { return false }
                                              return onPiece(piece)
                                          },
                                          onSample: nil)
+                // Hand seq 1's cells straight back, exactly as the rewrite path does for seq 2:
+                // `kv_unified` means every seq draws from ONE n_ctx-sized pool, and an API prompt is
+                // never reused as a ghost prefix, so holding these cells only starves the ghost — after
+                // sizeable API use the ghost's own prefill could no longer find a KV slot.
+                self.engine.releaseSeq(1)
                 onComplete(.success(()))
             } catch {
+                self.engine.releaseSeq(1)
                 onComplete(.failure(.decodeFailed(error)))
             }
         }
     }
+
+    // MARK: - API activity + liveness (idle-unload interlock)
+
+    private let apiActivityLock = NSLock()
+    private var apiRequestsInFlight = 0
+
+    // True while at least one API/MCP generation is queued or decoding. AppDelegate's idle-unload timer
+    // consults this so it can't tear the model down mid-stream.
+    var hasInFlightAPIRequests: Bool {
+        apiActivityLock.lock(); defer { apiActivityLock.unlock() }
+        return apiRequestsInFlight > 0
+    }
+
+    // Fired on MAIN whenever an API/MCP request arrives. AppDelegate wires this to the same
+    // "note activity, and lazily reload if the idle timer unloaded the model" path the keystroke and
+    // focus handlers use — the only thing that could previously wake an idle-unloaded engine.
+    var onExternalActivity: (() -> Void)?
+
+    private func noteAPIRequestStarted() {
+        apiActivityLock.lock(); apiRequestsInFlight += 1; apiActivityLock.unlock()
+        DispatchQueue.main.async { [weak self] in self?.onExternalActivity?() }
+    }
+
+    private func noteAPIRequestFinished() {
+        apiActivityLock.lock()
+        apiRequestsInFlight = max(0, apiRequestsInFlight - 1)
+        apiActivityLock.unlock()
+    }
+
+    // The context window an API/MCP request actually gets, for /v1/health to advertise honestly. The
+    // ghost's `maxContextTokens` is the USER's small "Context window size" setting and must not be
+    // reported as the server's capability.
+    var apiContextTokens: Int { engine.contextWindowTokens }
 
     // Engine's read-only chat-template metadata, used by the /v1/chat/completions route to decide
     // whether the model supports chat rendering (returns 400 + steers to /v1/completions if nil).
@@ -594,16 +683,27 @@ final class CompletionCoordinator {
         skipNextIKISample = true
         guard isEnabled, engine.isLoaded else { Diag.log("fire: skip (enabled=\(isEnabled) loaded=\(engine.isLoaded))"); return }
 
+        // #9: ONE AX resolution per fire, handed to every gate below. Each gate used to re-read the
+        // systemwide focused element and re-run the descendToEditable BFS (visitCap 64) for itself; a
+        // diag from a real machine caught the tree being walked ~14 times in 130 ms, every walk
+        // returning prefix: nil. nil here means nothing is focused — the gates below then see exactly
+        // what they saw before (isSecure false, no marked text, no host, prefix nil), so the
+        // capability-flicker gate and the AX-nudge branch still run.
+        let snapshot = context.resolveFocusSnapshot()
+        focusSnapshot = snapshot
+        let host = snapshot?.domainHost
+
         // FR-KC-4 / disabled-app+domain gate: never suggest in a secure field or a suppressed
         // app/domain (FR-PA-1/2). AppRules default is on everywhere; nil rules == on everywhere.
-        if context.isSecureField() { Diag.log("fire: skip secureField"); clearSuggestion(); return }
+        if snapshot?.isSecure == true { Diag.log("fire: skip secureField"); clearSuggestion(); return }
         // IME composition guard: while marked (preedit) text is live — CJK composition — never fire,
         // and clear any visible ghost (it overlaps the candidate window and an accept would splice into
         // the composition buffer). Best-effort single AX read; hosts that don't expose AXMarkedTextRange
         // return false and behave exactly as before (see EditContextTracker.hasMarkedText).
-        if context.hasMarkedText() { Diag.log("fire: skip markedText (IME composing)"); clearSuggestion(); return }
-        if let appRules, !appRules.isEnabled(bundleId: context.frontmostBundleId,
-                                             domain: context.frontmostDomainHost()) {
+        if let snapshot, context.hasMarkedText(in: snapshot) {
+            Diag.log("fire: skip markedText (IME composing)"); clearSuggestion(); return
+        }
+        if let appRules, !appRules.isEnabled(bundleId: context.frontmostBundleId, domain: host) {
             Diag.log("fire: skip disabledApp/domain \(context.frontmostBundleId ?? "?")"); clearSuggestion(); return
         }
 
@@ -619,13 +719,6 @@ final class CompletionCoordinator {
             Diag.log("fire: skip idleContext \(context.frontmostBundleId ?? "?")"); clearSuggestion(); return
         }
 
-        // Structured-input fields (browser address/omnibox, find bar, search boxes) are not prose —
-        // a ghost there offers URL/query garbage (the "aelo.com in the address bar" case). Skip unless
-        // force-activated.
-        if !forced, context.focusedFieldIsNonProse() {
-            Diag.log("fire: skip nonProseField \(context.frontmostBundleId ?? "?")"); clearSuggestion(); return
-        }
-
         // FR-CE-9: prefix-before-caret ONLY. nil => no editable focus. Read once and run it through the
         // capability-flicker gate (#3): a single nil read on the SAME focus session is usually a
         // transient republish (Catalyst fields drop their value mid-redraw), so hold the current ghost
@@ -635,19 +728,17 @@ final class CompletionCoordinator {
         // content" reveal); the raw prefix then ends with "On <date>, X wrote:" + ">"-lines and the
         // ghost would just continue the quoted prose. Strip the trailing quoted block so the prompt
         // sees the user's actual new prose (often empty → bail cleanly).
-        let originalPrefix = context.currentPrefix()
-        let rawPrefix = Self.prefixAfterEmailQuoteStrip(
-            originalPrefix, host: context.frontmostDomainHost())
+        let originalPrefix = snapshot?.prefix
+        let rawPrefix = Self.prefixAfterEmailQuoteStrip(originalPrefix, host: host)
         let hasContext = !((rawPrefix ?? "").isEmpty)
         if case let .suppress(misses) = capabilityGate.evaluate(hasContext: hasContext,
                                                                 focusSeq: context.focusChangeSequence) {
             Diag.log("fire: hold (capability flicker, miss \(misses))")
             return
         }
-        guard let prefix = rawPrefix, !prefix.isEmpty else {
+        guard let snapshot, let prefix = rawPrefix, !prefix.isEmpty else {
             let cause = (originalPrefix?.isEmpty == false) ? "quoted-strip consumed all" : "AX gave no text-before-caret"
             Diag.log("fire: skip prefix=nil/empty (app=\(context.frontmostBundleId ?? "?")) — \(cause)")
-            let host = context.frontmostDomainHost()
             // Web editors like Google Docs render to a canvas macOS AX can't read; rather than fail
             // silently, surface a one-time nudge (gated + de-duped by AXNudgeStore) pointing the user
             // at that app's own screen-reader setting.
@@ -673,11 +764,57 @@ final class CompletionCoordinator {
         // startGeneration. nil buffer / non-terminal → shellMode false, every prose path below unchanged.
         let shellMode = shellBuffer.map { ActivationPolicy.terminalMode($0) == .shellCommand } ?? false
 
+        // The three PURE gates run FIRST, immediately after the prefix read (#9). They are
+        // allocation-free string tests that reject the majority of pauses, and they used to sit BELOW
+        // `focusedFieldIsNonProse()` and the mid-line `caretAtLineEnd()` — four descendToEditable BFS
+        // passes plus descriptor/marker reads — so every rejected pause paid the full AX bill first.
+        // Reordering is outcome-neutral: each of those gates ends in the same clearSuggestion()+return,
+        // and none of the three reads state a probe establishes (they take only `prefix` and `shellMode`,
+        // both already resolved). The one place order was load-bearing is the emoji bypass below.
+
+        // FR-KC-5: only fire at a word/whitespace boundary where a continuation is
+        // meaningful — i.e. just after finishing a word (last char is alnum) or right
+        // after a separating space. Mid-token keystrokes are too noisy to suggest on.
+        // Shell mode bypasses this: shells autosuggest on every keystroke (paths/flags have no word
+        // boundaries — `cd /et`, `git -`), matching fish/zsh-autosuggestions behaviour.
+        // Emoji shortcodes bypass it too, and MUST: a partial shortcode may end on `_`, `+` or `-`
+        // (`:thumbs_`, `:+`), which is not a word boundary — before this gate moved above the emoji
+        // block those ghosts fired, and without the bypass the move would silently kill them. The
+        // predicate is only evaluated when the boundary test already failed.
+        guard shellMode || isMeaningfulBoundary(prefix) || isEmojiTrigger(prefix) else {
+            Diag.log("fire: skip notBoundary")
+            Diag.logContent("fire: skip notBoundary prefixTail=\"\(String(prefix.suffix(12)))\"")
+            clearSuggestion(); return
+        }
+
+        // FR-KC-5: require a minimum useful context (>= minPrefixChars non-space chars or >= 1
+        // completed word) before triggering — avoids firing on a lone letter or stray punctuation.
+        guard hasUsefulContext(prefix) else {
+            Diag.log("fire: skip thinContext")
+            Diag.logContent("fire: skip thinContext prefixTail=\"\(String(prefix.suffix(12)))\"")
+            clearSuggestion(); return
+        }
+
+        // Don't fire in the gap right after a finished sentence (terminal punctuation + a space): a
+        // continuation there is usually an unwanted new clause, not a completion of the user's text.
+        // Shell mode bypasses this — `.`/`!`/`?` are ordinary in paths and command args, not sentence ends.
+        guard shellMode || !Self.endsCompleteStatement(prefix) else {
+            Diag.log("fire: skip completeStatement")
+            clearSuggestion(); return
+        }
+
+        // Structured-input fields (browser address/omnibox, find bar, search boxes) are not prose —
+        // a ghost there offers URL/query garbage (the "aelo.com in the address bar" case). Skip unless
+        // force-activated.
+        if !forced, context.focusedFieldIsNonProse(in: snapshot) {
+            Diag.log("fire: skip nonProseField \(context.frontmostBundleId ?? "?")"); clearSuggestion(); return
+        }
+
         // Per-app "mid-line completions" (Cotypist): only suggest at end-of-line by default —
         // suppress when there's text after the caret on the same line. Mid-line ghosts overlap real
         // post-caret text and read as broken UX; users can opt in per-app to restore the old behavior.
         if !appSettings.resolve(\.midLine, forBundleId: context.frontmostBundleId, globalDefault: false),
-           !context.caretAtLineEnd() {
+           !context.caretAtLineEnd(in: snapshot) {
             Diag.log("fire: skip midLineOff \(context.frontmostBundleId ?? "?")")
             clearSuggestion(); return
         }
@@ -717,33 +854,6 @@ final class CompletionCoordinator {
             }
         }
 
-        // FR-KC-5: only fire at a word/whitespace boundary where a continuation is
-        // meaningful — i.e. just after finishing a word (last char is alnum) or right
-        // after a separating space. Mid-token keystrokes are too noisy to suggest on.
-        // Shell mode bypasses this: shells autosuggest on every keystroke (paths/flags have no word
-        // boundaries — `cd /et`, `git -`), matching fish/zsh-autosuggestions behaviour.
-        guard shellMode || isMeaningfulBoundary(prefix) else {
-            Diag.log("fire: skip notBoundary")
-            Diag.logContent("fire: skip notBoundary prefixTail=\"\(String(prefix.suffix(12)))\"")
-            clearSuggestion(); return
-        }
-
-        // FR-KC-5: require a minimum useful context (>= minPrefixChars non-space chars or >= 1
-        // completed word) before triggering — avoids firing on a lone letter or stray punctuation.
-        guard hasUsefulContext(prefix) else {
-            Diag.log("fire: skip thinContext")
-            Diag.logContent("fire: skip thinContext prefixTail=\"\(String(prefix.suffix(12)))\"")
-            clearSuggestion(); return
-        }
-
-        // Don't fire in the gap right after a finished sentence (terminal punctuation + a space): a
-        // continuation there is usually an unwanted new clause, not a completion of the user's text.
-        // Shell mode bypasses this — `.`/`!`/`?` are ordinary in paths and command args, not sentence ends.
-        guard shellMode || !Self.endsCompleteStatement(prefix) else {
-            Diag.log("fire: skip completeStatement")
-            clearSuggestion(); return
-        }
-
         // Shell-command mode: the terminal buffer IS the context, so the OCR path is irrelevant. Try the
         // zero-hallucination history fast path (a prior visible command that extends the typed stem) and,
         // on a hit, render it verbatim without ever touching the model. Secret-bearing matches are dropped
@@ -765,7 +875,7 @@ final class CompletionCoordinator {
         // just focus-in) reflects scrolling and late captures; the provider's ≤1/s throttle + the
         // storeOCRCache change-guard keep KV warm when the visible text hasn't changed.
         if useScreenOCR, !shellMode {
-            refreshOCRContextIfEnabled()
+            refreshOCRContextIfEnabled(prefix: prefix, snapshot: snapshot)
             // Don't paint a context-blind guess while this focus's first capture is still in flight — its
             // completion re-fires with real context. Only suppress when we have NOTHING yet (.pending, no
             // cache); a completed-but-empty capture (.ready) falls through to prefix-only.
@@ -776,9 +886,16 @@ final class CompletionCoordinator {
             }
         }
 
-        Diag.log("fire: START gen len=\(prefix.count)\(shellMode ? " [shell]" : "")")
+        // Post-caret conditioning: hand the model the text that FOLLOWS the caret so it stops writing
+        // sentences that duplicate or contradict the paragraph below (see postCaretBlock). Comes free
+        // from the snapshot — the same single AX read that produced the prefix — and is nil on the
+        // web/text-marker hosts, which can't see past the caret. Off in shell mode: the terminal buffer
+        // IS the context there, and assembleShellPrompt doesn't take context blocks at all.
+        let postCaret = shellMode ? nil : snapshot.suffix
+        Diag.log("fire: START gen len=\(prefix.count) post=\(postCaret?.count ?? -1)\(shellMode ? " [shell]" : "")")
         Diag.logContent("fire: START gen prefixTail=\"\(String(prefix.suffix(24)))\"")
-        startGeneration(prefix: prefix, shellMode: shellMode, terminalBuffer: shellBuffer)
+        startGeneration(prefix: prefix, postCaret: postCaret,
+                        shellMode: shellMode, terminalBuffer: shellBuffer)
     }
 
     // Render a history-derived shell completion verbatim, bypassing the model. Mirrors how
@@ -791,7 +908,20 @@ final class CompletionCoordinator {
         generationIsHealed = false
         generationContextLang = nil
         generationShellMode = true
+        // This ghost never goes through startGeneration, so it has no hoisted geometry/language of its
+        // own — clear any left over from the superseded generation and let renderSuggestion read live.
+        generationCaretRect = nil
+        generationFont = nil
+        generationPrefixLang = nil
         renderSuggestion(remainder)
+    }
+
+    // Cheap pure predicate: is the prefix currently inside an emoji `:shortcode`? Used only as the
+    // boundary-gate bypass above, so the emoji ghost keeps firing on a shortcode that ends on a
+    // non-word character (`:thumbs_`, `:+`). Never consults AX or the model.
+    private func isEmojiTrigger(_ prefix: String) -> Bool {
+        guard emojiEnabled, let emoji else { return false }
+        return emoji.isTrigger(prefix: prefix)
     }
 
     // Ghost opacity — Shadowtype is free and unlimited, so suggestions always show at full opacity.
@@ -838,12 +968,25 @@ final class CompletionCoordinator {
 
     // MARK: - Generation (newest-wins, deadline-drop)
 
-    private func startGeneration(prefix: String, shellMode: Bool = false, terminalBuffer: String? = nil) {
+    // `postCaret` is the text following the caret for THIS fire (nil when the host's AX read can't see
+    // past the caret, when nothing follows it, or in shell mode). It only reaches the prompt — never the
+    // ghost — see assembledPrompt / postCaretBlock.
+    private func startGeneration(prefix: String, postCaret: String? = nil,
+                                 shellMode: Bool = false, terminalBuffer: String? = nil) {
         let myGen = bumpGeneration()
         activePrefix = prefix
         generationShellMode = shellMode
         generationRTL = TextDirectionDetector.isRightToLeft(prefix)   // #14: once per generation, not per token
         glueGuardMemoKey = nil; glueGuardMemoResult = nil   // fresh prefix -> recompute the glue decision
+        // #9: everything else that is a pure function of the (now fixed) prefix or of a caret the paused
+        // user is not moving. Each of these ran on EVERY ~33 ms render tick: a full
+        // NLLanguageRecognizer pass over the whole prefix, plus an AX caret-rect and an AX caret-font
+        // round trip per frame.
+        generationPrefixLang = Self.driftPrefixLanguage(prefix)
+        let caret = currentFocusSnapshot.flatMap { context.caretRectOnScreen(in: $0) }
+            ?? context.caretRectOnScreen()
+        generationCaretRect = caret
+        generationFont = hostFont(caretHeight: (caret ?? .null).height)
 
         // FR-CE-5 (KV reuse): the engine keeps its context warm across calls and diffs the
         // full prefix internally — when `prefix` strictly extends the previous one only the
@@ -896,7 +1039,7 @@ final class CompletionCoordinator {
         // built from the terminal buffer (the OCR/style/clipboard context blocks don't apply there).
         let effectivePrompt = shellMode
             ? Self.assembleShellPrompt(prefix: promptPrefix, terminalBuffer: terminalBuffer)
-            : assembledPrompt(prefix: promptPrefix)
+            : assembledPrompt(prefix: promptPrefix, postCaret: postCaret)
         // Command-shaped sampling for shell mode: deterministic (temp 0.2), single line (stop at "\n",
         // useEngineStopPolicy=false → raw stream, no prose word/sentence caps). Same seq 0 for KV continuity.
         let genParams: SamplingParams = shellMode ? .commandDefaults : .ghostDefaults
@@ -1062,24 +1205,48 @@ final class CompletionCoordinator {
         // the prefix guard so it also resets when focusing an empty field. fire() then holds the first
         // guess until this focus's capture lands (see the .pending gate in fire()/refreshOCRContextIfEnabled).
         if useScreenOCR { storeOCRCache(nil); ocrCaptureState = .idle }
+        pendingWarm = nil
 
         guard let prefix = context.currentPrefix(), !prefix.isEmpty else { return }
+        // Same post-caret text the first real fire will assemble into the prompt (see postCaretBlock).
+        // Read here rather than left nil because a warm prefill that omits a block the first fire
+        // includes diverges from it and is discarded — the #11 failure this whole deferral exists for.
+        // Costs one extra AX read per FOCUS (not per keystroke), and it is served from the same
+        // value+range the prefix read already resolved.
+        let postCaret = context.suffixAfterCaret()
 
         // FR-CTX-1 (gated, default OFF): kick the on-screen OCR capture for this focus. fire() re-captures
         // on each typing pause too (so scrolling is reflected); storeOCRCache's change-guard keeps the
         // prepended OCR block — and thus the KV cache — stable while the visible text is unchanged.
-        refreshOCRContextIfEnabled()
+        refreshOCRContextIfEnabled(prefix: prefix)
         // FR-CTX-3: snapshot the style hint on focus-in too, so it stays stable through the typing burst
         // (warm KV) and its sort stays off the per-keystroke path.
         refreshStyleHintIfEnabled()
 
+        // #11: the OCR branch of refreshOCRContextIfEnabled is ASYNCHRONOUS — it returns with `ocrCache`
+        // still nil and lands the capture milliseconds later. Warming here anyway (what this used to do,
+        // under a comment claiming it assembled "exactly as startGeneration does") prefilled
+        // `Text:\n<prefix>` while the first real fire assembles `Context:\n<ocr>…Text:\n<prefix>`: the two
+        // streams diverge at token 0, so the ENTIRE warm prefill was discarded — and, because it ran on
+        // the serial inferenceQueue, the first real generation then queued behind a cold prefill it could
+        // not use. So warm only once the capture has landed; the capture's completion flushes this.
+        // The AX page-text branch is synchronous and has already set .ready, so browsers warm right away.
+        if useScreenOCR, ocrCaptureState == .pending {
+            Diag.log("warm: deferred (OCR capture pending)")
+            pendingWarm = (prefix, postCaret)
+            return
+        }
+        warmAssembledPrompt(prefix: prefix, postCaret: postCaret)
+    }
+
+    // Warm the SAME prompt startGeneration() will use (FR-CE-5): assemble the leading-context blocks
+    // (instructions/style/clipboard/OCR/post-caret) on main — exactly as startGeneration does at its dispatch
+    // point — so the first real keystroke after a focus switch reuses this warm cache instead of paying
+    // a cold prefill. Warming bare `prefix` would leave the cache mismatched whenever any context
+    // source is on.
+    private func warmAssembledPrompt(prefix: String, postCaret: String?) {
         let myGen = bumpGeneration()
-        // Warm the SAME prompt startGeneration() will use (FR-CE-5): assemble the leading-context blocks
-        // (instructions/style/clipboard/OCR, all paid-gated) on main — exactly as startGeneration does at
-        // its dispatch point — so the first real keystroke after a focus switch reuses this warm cache
-        // instead of paying a cold prefill. Warming bare `prefix` would leave the cache mismatched for
-        // licensed users with any context source on.
-        let warmPrompt = assembledPrompt(prefix: prefix)
+        let warmPrompt = assembledPrompt(prefix: prefix, postCaret: postCaret)
         inferenceQueue.async { [weak self] in
             guard let self else { return }
             _ = myGen
@@ -1087,6 +1254,15 @@ final class CompletionCoordinator {
             // never display warm-up output (side effect = warm ctx).
             try? self.engine.generate(prompt: warmPrompt, maxTokens: 1) { _ in false }
         }
+    }
+
+    // Run the focus warm that was deferred behind this focus's first capture (#11). No-op unless one is
+    // pending; cancel() drops it, so a keystroke or focus change that arrived first wins.
+    private func flushPendingWarm() {
+        guard let pending = pendingWarm else { return }
+        pendingWarm = nil
+        Diag.log("warm: capture landed -> warming deferred prefill")
+        warmAssembledPrompt(prefix: pending.prefix, postCaret: pending.postCaret)
     }
 
     // FR-LM-1: swap the active model SAFELY. InferenceEngine has no internal locking — its ctx/model are
@@ -1133,6 +1309,17 @@ final class CompletionCoordinator {
     func unloadModel() {
         cancel()
         inferenceQueue.async { [weak self] in self?.engine.unload() }
+    }
+
+    // Terminate-time unload. Same serialization as unloadModel() — the engine has no internal locking,
+    // so freeing its llama context anywhere but `inferenceQueue` can free it out from under an in-flight
+    // `llama_decode` — but BLOCKING, because at applicationWillTerminate the process is about to exit and
+    // an async unload would simply lose the race. AppDelegate used to call `engine.unload()` straight on
+    // main here: quitting mid-suggestion was a use-after-free crash-on-quit. cancel() first so the running
+    // decode bails between tokens and this wait stays short.
+    func unloadModelAndWait() {
+        cancel()
+        inferenceQueue.sync { engine.unload() }
     }
 
     // True when the engine has a model resident. AppDelegate reads this to decide whether an idle-unload
@@ -1357,7 +1544,10 @@ final class CompletionCoordinator {
         // Language-drift guard: a base model sometimes switches language mid-stream (an English ghost in a
         // Spanish doc). Suppress only on a confident, clearly-different language read (skip on the stale
         // remainder re-render). Conservative — never fires on a short/ambiguous prefix.
-        if prefixTransforms, Self.languageDrifts(prefix: activePrefix, suggestion: text) {
+        // #9: the prefix side of this read is hoisted to startGeneration — `activePrefix` is fixed for
+        // the whole generation, so re-running NLLanguageRecognizer over it on every streamed snapshot
+        // was pure waste. Only the (growing) suggestion is still detected per tick.
+        if prefixTransforms, Self.languageDrifts(prefixLanguage: generationPrefixLang, suggestion: text) {
             rejectRender("lang-drift"); return
         }
         // Context-language guard: when the surrounding conversation has a confident dominant language,
@@ -1382,7 +1572,11 @@ final class CompletionCoordinator {
         // FR-OV-3/6: anchor at the live caret; OverlayRenderer falls back to a chip if nil. A word-accept
         // remainder re-render passes a predicted anchor (see remainderAnchor) because the live caret is
         // stale until an async synthetic-injection host applies the keystrokes.
-        let caret = caretOverride ?? (context.caretRectOnScreen() ?? .null)
+        // #9: `generationCaretRect` is the caret resolved once for this generation. The user is paused
+        // and `activePrefix` is fixed, so it cannot move between the ~30 render ticks of one stream —
+        // re-reading it per tick was an AX round trip a frame. nil (emoji/correction/shell-history
+        // ghosts) still reads live.
+        let caret = caretOverride ?? generationCaretRect ?? (context.caretRectOnScreen() ?? .null)
         let caretDesc = caret.isNull ? "null" : "\(Int(caret.minX)),\(Int(caret.minY))"
         Diag.log("render: show len=\(display.count) caret=\(caretDesc)")
         Diag.logContent("render: show \"\(display.prefix(40))\"")
@@ -1391,7 +1585,9 @@ final class CompletionCoordinator {
         // session, displayed text, caret rect, fade opacity, RTL side, or host font. This kills the
         // post-accept "shift then snap back" jitter from a drifted AX caretRect while still re-anchoring
         // on a real change. #11: anchor the ghost left of the caret in a right-to-left field.
-        let font = hostFont(caretHeight: caret.height)
+        // Same hoist for the host font (#9): a second AX round trip per tick for a value that is fixed
+        // while the field, the caret and the generation are.
+        let font = generationFont ?? hostFont(caretHeight: caret.height)
         let candidate = OverlayStabilityGate.Rendered(
             text: display, caretRect: caret, focusSeq: context.focusChangeSequence,
             opacity: opacity, rtl: generationRTL, fontKey: OverlayStabilityGate.fontKey(font))
@@ -1419,7 +1615,9 @@ final class CompletionCoordinator {
     private func maybeNoteSmartComposeOverlap() {
         guard smartComposeNudgeEnabled else { return }
         guard SmartComposeNudgeStore.shared.mayStillPrompt() else { return }
-        guard let host = context.frontmostDomainHost(),
+        // Host comes from the fire()-time snapshot when it is still current (#9) — this runs on every
+        // successful render, and the live read walks the AX tree for kAXDocument each time.
+        guard let host = currentFocusSnapshot.map(\.domainHost) ?? context.frontmostDomainHost(),
               SmartComposeNudge.isApplicableHost(host) else { return }
         let fieldValue = context.focusedElementText()
         if SmartComposeNudge.detectsOverlap(fieldValue: fieldValue,
@@ -1438,7 +1636,10 @@ final class CompletionCoordinator {
     // it, else a system font sized from the caret line height (≈1.17× point size for typical fonts) so
     // web/Electron fields still get a size-matched ghost. nil => OverlayRenderer keeps its default.
     private func hostFont(caretHeight: CGFloat) -> NSFont? {
-        if let f = context.caretFont() {
+        // Reuse the fire()-time focus resolution when it is still the live one (#9) so the AX font read
+        // doesn't re-walk the tree; fall back to a live read only when there is no current snapshot.
+        let axFont = currentFocusSnapshot.map { context.caretFont(in: $0) } ?? context.caretFont()
+        if let f = axFont {
             Diag.log("font: host \(f.fontName) \(String(format: "%.1f", f.pointSize))pt (caretH=\(Int(caretHeight)))")
             return f
         }
@@ -1513,6 +1714,11 @@ final class CompletionCoordinator {
         pendingStreamSnapshot = nil
         suggestionVisible = false   // didSet notifies the Tab swallow only on transition
         generationCommitted = false // nothing on screen → the next reject may hide freely
+        // The hoisted per-generation geometry/language belong to the ghost that just went away (#9);
+        // the next show must resolve its own rather than paint at a dead caret.
+        generationCaretRect = nil
+        generationFont = nil
+        generationPrefixLang = nil
     }
 
     // MARK: - Host font watch (FR-OV-4)
@@ -1544,6 +1750,9 @@ final class CompletionCoordinator {
         let newKey = OverlayStabilityGate.fontKey(font)
         guard newKey != last.fontKey else { return }
         Diag.log("font: host font changed while visible -> re-render (\(last.fontKey ?? "default") -> \(newKey ?? "default"))")
+        // Keep the per-generation hoist in step, or a later coalesced render tick would repaint with the
+        // stale font this call just replaced (#9).
+        generationFont = font
         // Bypass emit()'s identical-text dedup: the text is unchanged by design, so emit() would drop
         // this deliberate in-place re-font. Drive overlay.show directly and resync the gate snapshot.
         overlay.show(text: last.text, at: caret, font: font, opacity: last.opacity, rtl: last.rtl,
@@ -1668,26 +1877,32 @@ final class CompletionCoordinator {
         }
     }
 
-    private func refreshOCRContextIfEnabled() {
+    // `prefix` is the user's live text-before-caret; it is what the capture is de-duplicated AGAINST
+    // before being cached (see dedupedCapture). `snapshot` is fire()'s single focus resolution, reused
+    // for the AX page read instead of re-walking the tree (#9).
+    private func refreshOCRContextIfEnabled(prefix: String,
+                                            snapshot: EditContextTracker.FocusSnapshot? = nil) {
         guard useScreenOCR else { return }
         let maxChars = ocrContextChars
 
         // AX-FIRST: in a browser/web host, read the visible page text directly via Accessibility —
         // exact text (no OCR errors), no Screen Recording permission, synchronous (so browsers never
-        // hit the .pending defer). The shared cleanup in assembledPrompt strips the user's draft +
-        // chrome regardless of source. Only fall back to OCR when there's no web area (native apps).
-        if let ax = context.pageContextText(), !ax.isEmpty {
+        // hit the .pending defer). Only fall back to OCR when there's no web area (native apps).
+        let axText = snapshot.map { context.pageContextText(in: $0) } ?? context.pageContextText()
+        if let ax = axText, !ax.isEmpty {
             // Denoise (drop chrome lines) + keep the tail (nearest the caret), mirroring the OCR
-            // path's cleanup so AX and OCR text are interchangeable downstream. The shared dedup in
-            // assembledPrompt then strips the user's own draft + the document echo.
+            // path's cleanup so AX and OCR text are interchangeable downstream.
             // dropShortLines:false — AX text is exact, so keep short signature/name rows the model
             // needs (the OCR-only chrome rule would otherwise discard them).
-            let text = ScreenContextProvider.clamp(
-                ScreenContextProvider.denoise(ax, dropShortLines: false), to: pageContextChars)
+            let text = dedupedCapture(
+                ScreenContextProvider.clamp(
+                    ScreenContextProvider.denoise(ax, dropShortLines: false), to: pageContextChars),
+                prefix: prefix)
             let changed = storeOCRCache(text)
             ocrCaptureState = .ready
             Diag.log("pagectx: ax raw=\(ax.count) kept=\(text?.count ?? -1) changed=\(changed)")
             Diag.logContent("pagectx: ax head=\"\(ax.prefix(200))\"")
+            flushPendingWarm()
             if changed { maybeRefireForContext() }
             return
         }
@@ -1703,9 +1918,11 @@ final class CompletionCoordinator {
             guard let self else { return }
             await MainActor.run {
                 guard self.context.frontmostBundleId == capturedBundleId else { return }
-                let changed = self.storeOCRCache(text)
+                let changed = self.storeOCRCache(self.dedupedCapture(text, prefix: prefix))
                 self.ocrCaptureState = .ready
                 Diag.log("ocr: refresh got \(text?.count ?? -1) chars changed=\(changed)")
+                // The capture this focus's KV warm was waiting on has landed (#11).
+                self.flushPendingWarm()
                 // Fresh context for the current viewport → re-fire so the ghost reflects it (closes the
                 // focus-in race + scroll staleness). Bounded to ONE upgrade per prefix so a dynamic
                 // screen can't keep regenerating and cycling the ghost during a pause.
@@ -1714,16 +1931,42 @@ final class CompletionCoordinator {
         }
     }
 
+    // Strip the user's own document + draft from a raw capture BEFORE it is cached (#10).
+    //
+    // This used to happen ONLY on the prompt path (assembledPrompt), so what was cached was the raw
+    // capture — draft and all. `storeOCRCache`'s whole job is to answer "did the visible text
+    // MEANINGFULLY change?", and with the growing draft baked in the answer was "yes" on essentially
+    // every fire: the change-guard was defeated, the context re-fire path ran constantly, and the cached
+    // block (which sits in FRONT of the prefix) moved under the KV cache every time. De-duplicating
+    // first makes the cached block hold still for as long as the screen actually holds still.
+    // The prompt path still runs the same two filters — by then the prefix has grown past this capture,
+    // and both filters are stable/idempotent, so the second pass is a cheap no-op in the steady state.
+    private func dedupedCapture(_ text: String?, prefix: String) -> String? {
+        let deDoc = ScreenContextProvider.removingDocumentEcho(text, prefix: prefix)
+        return ScreenContextProvider.removingDraftEcho(deDoc, draft: prefix)
+    }
+
     // Update the OCR context cache, returning whether it MEANINGFULLY changed. OCR jitter (reflowed line
     // breaks, trailing spaces) must not count as a change, or every re-capture would shift the prompt's
     // leading `Context:` tokens and force a cold prefill on the next keystroke (FR-CE-5). When unchanged
     // we keep the existing value so KV stays warm and the caller skips the re-fire.
+    // Main-thread only (every caller is), which is what lets it also latch `ocrCacheLang`.
     @discardableResult
     private func storeOCRCache(_ text: String?) -> Bool {
-        ocrLock.lock(); defer { ocrLock.unlock() }
-        if Self.ocrTextEquivalent(ocrCache, text) { return false }
-        ocrCache = text
-        return true
+        ocrLock.lock()
+        let changed = !Self.ocrTextEquivalent(ocrCache, text)
+        if changed { ocrCache = text }
+        ocrLock.unlock()
+        // Latch the steer language to the CAPTURE, not to each prompt assembly (#10). Detected on the
+        // caret-local tail exactly as the assembly used to do it, but ONCE per accepted capture: a
+        // borderline read re-run per fire could flip between two fires of the same burst, and that name
+        // goes into the `Text (in <Language>):` marker sitting immediately before the prefix — a changed
+        // prompt head, i.e. a full cold re-prefill, every time it flipped.
+        if changed {
+            ocrCacheLang = text.map { Self.caretLocalContextTail($0) }
+                .flatMap { Self.dominantLanguage($0, minConfidence: 0.70) }
+        }
+        return changed
     }
 
     // Two OCR blocks are equivalent when they match after collapsing all whitespace/newline runs to a
@@ -1777,11 +2020,15 @@ final class CompletionCoordinator {
     //   3. clipboard            (FR-CTX-2) — current pasteboard text.
     //   4. OCR                  (FR-CTX-1, Free) — recent on-screen text (its own `useScreenOCR` toggle,
     //                                              NOT licence-gated; it is a Free feature).
+    //   5. postCaret            — the text FOLLOWING the caret (see postCaretBlock), last so it sits
+    //                             immediately before the `Text:` marker. nil off the native AX read
+    //                             paths and in shell mode.
     // wrapped as `Context:\n<blocks>\n\nText:\n<prefix>` so the base model conditions on the context
     // (see assemblePrompt). The prefix STAYS the forward-from-caret tail (FR-CE-9). Free default
-    // (no licence, OCR off) yields exactly `prefix` up to the budget, and an ANCHORED tail window of it
-    // beyond — either way the prompt head holds still across a burst, so KV reuse is preserved.
-    private func assembledPrompt(prefix: String) -> String {
+    // (no licence, OCR off, nothing after the caret) yields exactly `prefix` up to the budget, and an
+    // ANCHORED tail window of it beyond — either way the prompt head holds still across a burst, so KV
+    // reuse is preserved.
+    private func assembledPrompt(prefix: String, postCaret: String?) -> String {
         // Resolve each (already-gated-ready) source, then hand the gating + ordering + join to the pure
         // static below so it is unit-testable without AX/model/overlay (the leak-when-unlicensed property
         // is the security-critical invariant). Style hint is the focus-in snapshot (stable across the
@@ -1822,8 +2069,12 @@ final class CompletionCoordinator {
         // tail -> ca:1.00; the base model then drifts "has trob" -> Spanish "trobado"). The recent
         // messages at the tail carry the reply language. (Never detect from the short prefix — 8 chars of
         // "has trob" misreads as English at 0.95.)
-        let ctxLang = (useScreenOCR ? ocr.map { Self.caretLocalContextTail($0) } : nil)
-            .flatMap { Self.dominantLanguage($0, minConfidence: 0.70) }
+        // Read from the per-CAPTURE latch rather than re-detecting here (#10): this runs on every fire,
+        // and a borderline read that flips between fires rewrites the `Text (in X):` marker sitting
+        // immediately before the prefix — the prompt head — which costs a full cold re-prefill. Still
+        // gated on the OCR block actually existing, so a run with no screen context keeps the bare
+        // `Text:` marker exactly as before.
+        let ctxLang = (useScreenOCR && ocr != nil) ? ocrCacheLang : nil
 
         let assembled = Self.assemblePrompt(
             prefix: prefix, isLicensed: isLicensed,
@@ -1831,6 +2082,7 @@ final class CompletionCoordinator {
             styleHint: styleHint, styleEnabled: styleProfileEnabled,
             clipboard: clip, clipboardEnabled: clipboardContextEnabled,
             ocr: ocr, ocrEnabled: useScreenOCR,
+            postCaret: postCaret,
             steerLanguageName: ctxLang.flatMap(Self.englishLanguageName),
             totalChars: promptCharBudget)
         // Arm renderSuggestion's context-drift suppression ONLY when the OCR block actually SURVIVED the
@@ -1875,9 +2127,52 @@ final class CompletionCoordinator {
         return max(256, Int(Double(tokens) * 3.5) - framingReserve)
     }
 
+    // MARK: - Post-caret conditioning (suffix awareness)
+
+    // How much post-caret text ever reaches the prompt. Deliberately far below
+    // EditContextTracker.maxSuffixChars (400 UTF-16 units): the job is to let the model SEE that a
+    // paragraph follows so it doesn't duplicate or contradict it, and the first couple of sentences
+    // carry that; anything more is budget taken from the caret text and from screen context. Bytes, to
+    // match the allocator's unit.
+    static let postCaretContextBytes = 240
+
+    // Pure (testable): the `After the cursor:` context block for the text following the caret, or nil
+    // when there is nothing worth telling the model.
+    //
+    // WHY this block exists: caretAtLineEnd() means "the next character is a newline", NOT
+    // end-of-document, so when the user edits paragraph 2 of a 5-paragraph mail the model has been told
+    // nothing at all about the three paragraphs below and happily writes a sentence that duplicates or
+    // contradicts them. This is the base-model route to fixing that: no FIM tokens (the engine supports
+    // params.fim, but no catalog model exposes the tokens, so that path is unreachable today) — just one
+    // more `Header:\n…` block inside the existing `Context:` region, the same document-shaped framing
+    // that makes a base model treat `Context:` as reference material and `Text:` as the live
+    // continuation. The label deliberately avoids the literal `Text:` / `Text (` sequences, which are
+    // stop markers on the rewrite path (SamplingParams.rewriteDefaults) and the marker this prompt ends
+    // with; "cursor" rather than the codebase's "caret" because this string is read by a model trained
+    // on ordinary prose, not by a developer.
+    //
+    // KV STABILITY (the make-or-break — this block sits in FRONT of the prefix): every step here is a
+    // pure function of `suffix` alone, and `suffix` itself is the text the user is NOT editing, so the
+    // whole block is byte-identical across a typing burst. The cut keeps the HEAD (nearest the caret)
+    // and is taken at a fixed cost, never at "whatever the budget has left" — see the atomic flag in
+    // assemblePrompt for the other half of that guarantee.
+    static func postCaretBlock(_ suffix: String?,
+                               maxBytes: Int = CompletionCoordinator.postCaretContextBytes) -> String? {
+        guard let suffix else { return nil }
+        // Trailing newlines at the end of a document, or the blank line the caret sits above, are the
+        // common case and say nothing. Requiring real content also keeps the block (and therefore the
+        // prompt head) from appearing and disappearing over pure whitespace churn.
+        let trimmed = suffix.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 2 else { return nil }
+        let windowed = PromptSectionBudget.headWithinCost(trimmed, maxCost: maxBytes)
+        guard !windowed.isEmpty else { return nil }
+        return "After the cursor:\n" + windowed
+    }
+
     // Pure leading-context assembly + GATING (testable: no AX/model/overlay). Prepends, in order:
     //   1. instruction (paid, FR-PA-3)  2. styleHint (paid, FR-CTX-3)  3. clipboard (paid, FR-CTX-2)
     //   4. ocr (FREE, FR-CTX-1 — gated only by its own `ocrEnabled`, NOT by the licence)
+    //   5. postCaret (FREE — the text after the caret, see postCaretBlock; nil disables it entirely)
     // wrapped as `Context:\n<blocks>\n\nText:\n<prefix>`, the prefix STAYING the forward-from-caret tail
     // (FR-CE-9). The three PAID blocks are
     // dropped whenever `isLicensed` is false (or their toggle is off / value empty), so a Free user can
@@ -1896,6 +2191,7 @@ final class CompletionCoordinator {
                                styleHint: String?, styleEnabled: Bool,
                                clipboard: String?, clipboardEnabled: Bool,
                                ocr: String?, ocrEnabled: Bool,
+                               postCaret: String? = nil,
                                steerLanguageName: String? = nil,
                                totalChars: Int = .max) -> (prompt: String, ocrKept: Bool) {
         // A base model's tokenizer attaches the leading space to each word (SentencePiece `▁word`), so a
@@ -1906,28 +2202,36 @@ final class CompletionCoordinator {
         // reconcileLeadingSpace drops the echoed leading space against the original (untrimmed) prefix.
         let prefix = trimmingTrailingInlineWhitespace(prefix)
 
-        // Build the gated context sections in render order (instruction → style → clipboard → OCR),
-        // plus the prefix at top priority so it survives a tight budget. Priorities set the FILL order
+        // Build the gated context sections in render order (instruction → style → clipboard → OCR →
+        // post-caret), plus the prefix at top priority so it survives a tight budget. Priorities set the FILL order
         // (prefix first, style last); the allocator trims/drops lowest-priority blocks to fit totalChars.
         var sections: [PromptSection] = []
-        // `directive` marks a block whose MEANING LIVES IN ITS WORDING — the user's instruction and the
-        // style hint. Trimming those doesn't degrade them, it changes them: "Always reply in formal
-        // Spanish, never use contractions" cut to its tail is the different instruction "never use
-        // contractions", and the style hint cut anywhere loses the explanatory label that makes its word
-        // list interpretable at all, leaving a bare semicolon list the model reads as content to copy. So
-        // a directive declares minChars == its full cost: the allocator takes it WHOLE or drops it.
-        // `.preserveStart` is the matching end (the head carries the directive's subject) — with the
-        // all-or-nothing minChars it never actually trims, but `.preserveEnd` here would be wrong the
-        // moment either number moves. The prose blocks (clipboard, OCR) keep `.preserveEnd`/minChars 0:
-        // their tail is the part nearest the caret and a fragment of it is still useful context.
-        func addContext(_ s: String?, name: String = "ctx", priority: Int, directive: Bool = false) {
+        // `atomic` marks a block the allocator must take WHOLE or drop (minChars == its full cost), kept
+        // from the `.preserveStart` end. Two different kinds of block need that shape:
+        //   • DIRECTIVES — the user's instruction and the style hint — whose MEANING LIVES IN THEIR
+        //     WORDING. Trimming those doesn't degrade them, it changes them: "Always reply in formal
+        //     Spanish, never use contractions" cut to its tail is the different instruction "never use
+        //     contractions", and the style hint cut anywhere loses the explanatory label that makes its
+        //     word list interpretable at all, leaving a bare semicolon list the model reads as content to
+        //     copy. `.preserveStart` is the matching end (the head carries the directive's subject) —
+        //     with the all-or-nothing minChars it never actually trims, but `.preserveEnd` here would be
+        //     wrong the moment either number moves.
+        //   • The POST-CARET block, for a KV reason rather than a meaning one: it is pre-windowed to a
+        //     fixed cost before it gets here, so letting the allocator re-cut it to whatever the growing
+        //     prefix leaves over would shrink it by a few bytes per keystroke — and it sits in FRONT of
+        //     the prefix, so that is a mutating prompt head and a cold re-prefill every fire. Whole or
+        //     absent means the head can only change once, when the budget crosses. `.preserveStart` is
+        //     also the right end there (the text NEAREST the caret is the part that matters).
+        // The prose blocks (clipboard, OCR) keep `.preserveEnd`/minChars 0: their tail is the part
+        // nearest the caret and a fragment of it is still useful context.
+        func addContext(_ s: String?, name: String = "ctx", priority: Int, atomic: Bool = false) {
             guard let s, !s.isEmpty else { return }
             // maxChars is a BYTE budget (PromptSectionBudget costs in UTF-8 bytes); each section's own
             // max is its full byte length so it's only trimmed when the TOTAL budget binds.
             let cost = PromptSectionBudget.cost(s)
             sections.append(PromptSection(name: name, content: s, priority: priority,
-                                          minChars: directive ? cost : 0, maxChars: cost,
-                                          truncation: directive ? .preserveStart : .preserveEnd))
+                                          minChars: atomic ? cost : 0, maxChars: cost,
+                                          truncation: atomic ? .preserveStart : .preserveEnd))
         }
         // Priority is the FILL order — the reverse of the DROP order — and is independent of the render
         // order below (PromptSectionBudget.allocate returns survivors in their original array order), so
@@ -1935,10 +2239,23 @@ final class CompletionCoordinator {
         // below screen context: a vocabulary hint nudges word choice, while the screen text is what the
         // next word is actually ABOUT. At its old 60 it outranked both clipboard and OCR and starved the
         // far more informative context whenever the budget bound.
-        if isLicensed { addContext(instruction, priority: 80, directive: true) }   // FR-PA-3 (paid)
-        if isLicensed && styleEnabled { addContext(styleHint, priority: 10, directive: true) } // FR-CTX-3 (paid)
+        if isLicensed { addContext(instruction, priority: 80, atomic: true) }      // FR-PA-3 (paid)
+        if isLicensed && styleEnabled { addContext(styleHint, priority: 10, atomic: true) } // FR-CTX-3 (paid)
         if isLicensed && clipboardEnabled { addContext(clipboard, priority: 40) }  // FR-CTX-2 (paid)
         if ocrEnabled { addContext(ocr, name: "ocr", priority: 20) }               // FR-CTX-1 (FREE)
+        // Post-caret text, LAST so it renders immediately before the `Text:` marker — the model reads
+        // "here is what follows the cursor", then the live text to continue, and the adjacency is what
+        // makes the relationship legible to a base model. Appending it at the END of the context region
+        // also leaves every earlier block's bytes untouched, so a fire where it appears/disappears still
+        // shares a KV prefix with one where it didn't, up to this point.
+        //
+        // Priority 30 — below the prefix (which is never starved: 1000) and below the paid instruction
+        // and clipboard, but ABOVE screen context (20) and the style hint (10). Ranking it at the very
+        // bottom would have made it dead weight in practice: the OCR block declares its whole length as
+        // maxChars, so under a binding budget it consumes everything the higher priorities left and any
+        // block below it is dropped. This one is capped at postCaretContextBytes, ~7% of the default
+        // budget, so it cannot meaningfully crowd out anything above it either way.
+        addContext(postCaretBlock(postCaret), name: "postCaret", priority: 30, atomic: true)
         // The prefix (kept nearest-the-caret tail) — top priority, so it still wins under contention, but
         // CAPPED so it can't take the whole budget. It used to declare its own full length as maxChars:
         // the allocator fills highest-priority first, so any draft longer than the budget consumed 100% of
@@ -1955,15 +2272,26 @@ final class CompletionCoordinator {
         // every fire (see PromptSectionBudget.anchoredTail). Pre-windowed here, so the section declares its
         // own already-fitting length and the allocator never re-cuts it unanchored.
         let windowedPrefix = PromptSectionBudget.anchoredTail(prefix, maxCost: prefixCap)
-        let prefixSection = PromptSection(name: "prefix", content: windowedPrefix, priority: 1000,
-                                          minChars: 0,
-                                          maxChars: PromptSectionBudget.cost(windowedPrefix),
-                                          truncation: .preserveEnd)
-        sections.append(prefixSection)
-
-        let allocated = PromptSectionBudget.allocate(sections, totalChars: totalChars)
-        let outPrefix = allocated.first(where: { $0.name == "prefix" })?.content ?? prefix
-        let blocks = allocated.filter { $0.name != "prefix" }.map(\.content)
+        // Allocate the context blocks against the RESERVED prefix cap, not the prefix's live cost — and
+        // hence in a separate pass, with the prefix kept out of `sections` entirely.
+        //
+        // This is the whole ballgame for KV reuse. anchoredTail pins the kept window's START, but its
+        // LENGTH still grows by one byte per keystroke (the window start holds while the text extends).
+        // With the prefix in the same allocation at priority 1000 it was filled FIRST, so `remaining`
+        // shrank by that same byte every fire, and the OCR block — which declares its full length as
+        // maxChars and sits in FRONT of the prefix — got cut one byte differently each time. Measured:
+        // 120 distinct prompt heads across 120 keystrokes, i.e. a full cold prefill on every single fire,
+        // silently undoing the anchoring. Budgeting the blocks against the fixed reservation makes their
+        // bytes independent of how much of the prefix window is currently filled.
+        // Reserve for the prefix what it actually occupies, rounded UP to the anchor step: constant
+        // between re-anchors (so the blocks' bytes hold still), but still small when the draft is short,
+        // so a short draft does not starve the context of two thirds of the budget for nothing.
+        let prefixReserve = PromptSectionBudget.quantizedReservation(
+            cost: PromptSectionBudget.cost(windowedPrefix), maxCost: prefixCap)
+        let contextBudget = sections.isEmpty ? 0 : max(0, totalChars - prefixReserve)
+        let allocated = PromptSectionBudget.allocate(sections, totalChars: contextBudget)
+        let outPrefix = windowedPrefix
+        let blocks = allocated.map(\.content)
         let ocrKept = allocated.contains { $0.name == "ocr" }
 
         guard !blocks.isEmpty else { return (outPrefix, ocrKept) }
@@ -2303,11 +2631,27 @@ final class CompletionCoordinator {
     // (NaturalLanguage only, no I/O) and testable.
     static func languageDrifts(prefix: String, suggestion: String,
                                minPrefixChars: Int = 40, minConfidence: Double = 0.80) -> Bool {
+        languageDrifts(prefixLanguage: driftPrefixLanguage(prefix, minPrefixChars: minPrefixChars,
+                                                           minConfidence: minConfidence),
+                       suggestion: suggestion, minConfidence: minConfidence)
+    }
+
+    // The prefix half of the drift read, split out so the caller can compute it ONCE per generation
+    // instead of once per streamed render tick (#9) — `activePrefix` cannot change while the model is
+    // streaming. nil = too short or not confident enough, i.e. the guard must not fire.
+    static func driftPrefixLanguage(_ prefix: String,
+                                    minPrefixChars: Int = 40, minConfidence: Double = 0.80) -> NLLanguage? {
         let p = prefix.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard p.count >= minPrefixChars else { return nil }
+        return dominantLanguage(p, minConfidence: minConfidence)
+    }
+
+    // The per-tick half: only the (growing) suggestion is re-read.
+    static func languageDrifts(prefixLanguage: NLLanguage?, suggestion: String,
+                               minConfidence: Double = 0.80) -> Bool {
+        guard let pl = prefixLanguage else { return false }
         let s = suggestion.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard p.count >= minPrefixChars, s.count >= 4 else { return false }
-        guard let pl = dominantLanguage(p, minConfidence: minConfidence),
-              let sl = dominantLanguage(s, minConfidence: minConfidence) else { return false }
+        guard s.count >= 4, let sl = dominantLanguage(s, minConfidence: minConfidence) else { return false }
         return pl != sl
     }
 

--- a/Sources/Shadowtype/CompletionCoordinator.swift
+++ b/Sources/Shadowtype/CompletionCoordinator.swift
@@ -514,6 +514,12 @@ final class CompletionCoordinator {
     // queue promptly, and is itself superseded (returns nothing) if the user triggers again. Unlike the
     // ghost path this is a ONE-SHOT instruction-style few-shot prompt (RewriteAction), so the KV cache
     // resets to a cold prefill — acceptable for an explicit, occasional action.
+    //
+    // It runs on its OWN sequence (2), never the ghost's seq 0. The few-shot prompt diverges from the
+    // ghost stream at token 0, so the engine's reuseLength() returns 0 and it resets the seq — on seq 0
+    // that dropped the ENTIRE ghost prefix, making the first keystroke after every rewrite pay a second
+    // full cold prefill. Seq 1 is the API/MCP slot (see runRawCompletion), so rewrite takes 2; the
+    // engine's n_seq_max is 4 and kv_unified means the seqs share one n_ctx pool rather than carving it up.
     func rewrite(selection: String, action: RewriteAction, completion: @escaping (String?) -> Void) {
         guard isLicensed, engine.isLoaded, !selection.isEmpty else { completion(nil); return }
         let tone = instructionStore?.effectiveInstruction(bundleId: context.frontmostBundleId)
@@ -523,14 +529,9 @@ final class CompletionCoordinator {
         let lang = Self.dominantLanguage(selection, minConfidence: 0.50).flatMap(Self.englishLanguageName)
         let prompt = RewriteAction.prompt(for: action, selection: selection, userTone: tone, language: lang)
         let budget = RewriteAction.maxTokens(forSelection: selection)
-        // A rewrite is a FULL multi-sentence transformation, not an inline ghost. The ghost stop
-        // policy (maxWords cap + first-sentence/newline stop) would truncate it — a multi-sentence
-        // selection came back as just the first ~5 words ("Have you installed the beta"). Stream raw
-        // tokens governed only by maxTokens + our few-shot stop strings: keep the ghost's low-temp,
-        // repeat-penalized sampling (good for faithful rewrites) but turn OFF the engine stop policy.
-        var params = SamplingParams.ghostDefaults
-        params.useEngineStopPolicy = false
-        params.stopStrings = ["\nText:", "\nText (", "\nRewritten:"]
+        // Ghost sampling minus the ghost stop policy, plus a fresh seed per call so ⌘R redo actually
+        // re-rolls instead of replaying the same text (see SamplingParams.rewriteDefaults).
+        let params = SamplingParams.rewriteDefaults()
         let myGen = bumpGeneration()
         engine.requestCancel()     // stop a running ghost decode so the serial queue frees up promptly
         Diag.log("rewrite: action=\(action.rawValue) selLen=\(selection.count) budget=\(budget) lang=\(lang ?? "auto")")
@@ -538,7 +539,7 @@ final class CompletionCoordinator {
             guard let self else { return }
             var acc = ""
             do {
-                try self.engine.generate(prompt: prompt, maxTokens: budget, seqID: 0, params: params,
+                try self.engine.generate(prompt: prompt, maxTokens: budget, seqID: 2, params: params,
                                          requiredPrefix: nil, onToken: { piece in
                     guard self.isCurrent(myGen) else { return false }
                     acc += piece
@@ -549,6 +550,10 @@ final class CompletionCoordinator {
             } catch {
                 Diag.log("rewrite: ERROR \(error)")
             }
+            // Hand seq 2's cells straight back: `kv_unified` shares one n_ctx pool, and a rewrite prompt
+            // always diverges at token 0, so this cache can never be reused — holding it would just starve
+            // the ghost (ghost + rewrite both near the cap exceed the pool and llama_decode fails).
+            self.engine.releaseSeq(2)
             let cleaned = RewriteAction.cleanOutput(acc, selectionWasMultiline: selection.contains("\n"))
             DispatchQueue.main.async {
                 guard self.isCurrent(myGen) else { return }
@@ -865,8 +870,9 @@ final class CompletionCoordinator {
         generationIsHealed = (requiredPrefix != nil)
 
         // FR-CTX-1/2/3, FR-PA-3: assemble leading context, each block gated by isLicensed + its toggle,
-        // then the user's prefix as the forward-from-caret tail. Default Free -> effectivePrompt == prefix,
-        // so KV reuse and behavior are unchanged. Shell mode swaps in the few-shot `$ command` framing
+        // then the user's prefix as the forward-from-caret tail. Default Free -> effectivePrompt is the
+        // prefix (anchor-windowed once it outgrows the budget), so KV reuse holds across a typing burst.
+        // Shell mode swaps in the few-shot `$ command` framing
         // built from the terminal buffer (the OCR/style/clipboard context blocks don't apply there).
         let effectivePrompt = shellMode
             ? Self.assembleShellPrompt(prefix: promptPrefix, terminalBuffer: terminalBuffer)
@@ -1729,7 +1735,8 @@ final class CompletionCoordinator {
     //                                              NOT licence-gated; it is a Free feature).
     // wrapped as `Context:\n<blocks>\n\nText:\n<prefix>` so the base model conditions on the context
     // (see assemblePrompt). The prefix STAYS the forward-from-caret tail (FR-CE-9). Free default
-    // (no licence, OCR off) yields exactly `prefix`, so KV reuse + behaviour are unchanged.
+    // (no licence, OCR off) yields exactly `prefix` up to the budget, and an ANCHORED tail window of it
+    // beyond — either way the prompt head holds still across a burst, so KV reuse is preserved.
     private func assembledPrompt(prefix: String) -> String {
         // Resolve each (already-gated-ready) source, then hand the gating + ordering + join to the pure
         // static below so it is unit-testable without AX/model/overlay (the leak-when-unlicensed property
@@ -1760,8 +1767,9 @@ final class CompletionCoordinator {
 
         // Language steering (user choice: match the surrounding conversation, else hide). Detect the
         // dominant language of the SAME on-screen context that goes into the prompt (chrome already
-        // stripped). Stash it for renderSuggestion's drift suppression, and pass its English name to the
-        // assembler so the `Text (in <Language>):` marker steers the base model toward it. nil when
+        // stripped). Stash it for renderSuggestion's drift suppression (only if that context survives the
+        // budget — see below), and pass its English name to the assembler so the `Text (in <Language>):`
+        // marker steers the base model toward it. nil when
         // there's no confident single-language context → behaviour unchanged.
         // Detect the steer language from the context NEAREST the caret, not the whole capture. Slack and
         // most chat apps expose no AX web-area, so the context is a full-screen OCR dominated by English
@@ -1772,9 +1780,8 @@ final class CompletionCoordinator {
         // "has trob" misreads as English at 0.95.)
         let ctxLang = (useScreenOCR ? ocr.map { Self.caretLocalContextTail($0) } : nil)
             .flatMap { Self.dominantLanguage($0, minConfidence: 0.70) }
-        generationContextLang = ctxLang
 
-        return Self.assemblePrompt(
+        let assembled = Self.assemblePrompt(
             prefix: prefix, isLicensed: isLicensed,
             instruction: instruction,
             styleHint: styleHint, styleEnabled: styleProfileEnabled,
@@ -1782,6 +1789,15 @@ final class CompletionCoordinator {
             ocr: ocr, ocrEnabled: useScreenOCR,
             steerLanguageName: ctxLang.flatMap(Self.englishLanguageName),
             totalChars: promptCharBudget)
+        // Arm renderSuggestion's context-drift suppression ONLY when the OCR block actually SURVIVED the
+        // budget. A long draft eats most of the budget and the lowest-priority OCR block is dropped — the
+        // model then never sees that context at all, so hiding its completion for "drifting" from it hides
+        // a perfectly good ghost on evidence the model was never given. Committed after assembly for that
+        // reason (it used to be set from the pre-assembly detection, which couldn't know). Deliberately
+        // asymmetric with the steer marker above, which still carries the detected name: steering toward
+        // the language the user is actually writing in is harmless when the block is gone; HIDING is not.
+        generationContextLang = assembled.ocrKept ? ctxLang : nil
+        return assembled.prompt
     }
 
     // English display name for a detected language ("ca" -> "Catalan"), used to steer the base model in
@@ -1791,11 +1807,29 @@ final class CompletionCoordinator {
         Locale(identifier: "en_US").localizedString(forLanguageCode: language.rawValue)
     }
 
-    // #8: global character ceiling for the assembled prompt (context blocks + prefix). ~6000 chars
-    // ≈1500 tokens — well inside the engine's 4096-token window with generation headroom — so the
-    // per-feature caps (OCR/clipboard/style) plus this total guard keep the caret text from being
-    // crowded out. The prefix is filled first and never starved.
-    private let promptCharBudget = 6000
+    // #8: global BYTE ceiling for the assembled prompt (context blocks + prefix). MIRRORED FROM the
+    // engine's live token cap by AppDelegate.syncToggles, right next to where it sets
+    // `engine.maxContextTokens` — THE TWO MUST STAY IN SYNC. They used to drift: this was hardcoded to
+    // 6000 ("well inside the engine's 4096-token window"), but the window is the USER's
+    // `shadowtype.contextWindowTokens` setting, 1024 by default. InferenceEngine.generate() front-trims
+    // the tokenized prompt to that cap, and the FRONT is exactly where `Context:\n` + instruction +
+    // style + clipboard + OCR live — so every context block we paid to build was decapitated and the
+    // model got a headless fragment glued to `\n\nText:\n`, the flat-document shape the framing below
+    // exists to avoid. This default mirrors the 1024-token default of that key.
+    var promptCharBudget = CompletionCoordinator.promptBudgetBytes(forContextTokens: 1024)
+
+    // Pure (testable): prompt bytes that safely fit `tokens` tokens. 3.5 bytes/token is deliberately
+    // BELOW the ~4 bytes/token of mixed English prose: under-filling only wastes a little of the window,
+    // while over-filling reintroduces the front-trim that eats the context blocks. The reserve covers the
+    // framing the section budget is not charged for — `Context:\n`, the `\n\n` block separators and the
+    // longest `\n\nText (in <Language>):\n` marker.
+    static func promptBudgetBytes(forContextTokens tokens: Int) -> Int {
+        let framingReserve = 64
+        // Clamped before the Double math: the value comes from user defaults, and an absurd hand-edited
+        // one would otherwise overflow the Int conversion and trap. The engine clamps to n_ctx anyway.
+        let tokens = min(max(0, tokens), 32_768)
+        return max(256, Int(Double(tokens) * 3.5) - framingReserve)
+    }
 
     // Pure leading-context assembly + GATING (testable: no AX/model/overlay). Prepends, in order:
     //   1. instruction (paid, FR-PA-3)  2. styleHint (paid, FR-CTX-3)  3. clipboard (paid, FR-CTX-2)
@@ -1804,19 +1838,22 @@ final class CompletionCoordinator {
     // (FR-CE-9). The three PAID blocks are
     // dropped whenever `isLicensed` is false (or their toggle is off / value empty), so a Free user can
     // never leak a paid context source. Empty result (no blocks) returns exactly `prefix` (KV reuse safe).
-    // `totalChars` is the global character budget for the whole prompt (context blocks + prefix). It
+    // `totalChars` is the global BYTE budget for the whole prompt (context blocks + prefix). It
     // defaults to "unbounded" so existing callers/tests keep the exact prior behavior; the live caller
     // passes a finite budget so a noisy screen capture can't crowd out the caret text or blow the
     // context window (#8 PromptSectionBudget). The prefix is given top fill-priority and is never
     // dropped — the lower-priority context blocks (OCR first, then clipboard, style, instruction) trim
-    // or drop to fit. Surviving blocks keep their original render order.
+    // or drop to fit — but it is itself capped at a share of the budget so it can't drop ALL of them
+    // (see prefixCap below). Surviving blocks keep their original render order.
+    // Returns the prompt plus whether the OCR block survived the budget, which the caller needs to decide
+    // if the render-time context-language suppression may be armed (see assembledPrompt).
     static func assemblePrompt(prefix: String, isLicensed: Bool,
                                instruction: String?,
                                styleHint: String?, styleEnabled: Bool,
                                clipboard: String?, clipboardEnabled: Bool,
                                ocr: String?, ocrEnabled: Bool,
                                steerLanguageName: String? = nil,
-                               totalChars: Int = .max) -> String {
+                               totalChars: Int = .max) -> (prompt: String, ocrKept: Bool) {
         // A base model's tokenizer attaches the leading space to each word (SentencePiece `▁word`), so a
         // prompt ending in a bare space is a "dangling space" the model can't continue cleanly — it
         // degrades into word-salad ("…castillo y que " -> "2 erme en un r es una una…", while the same
@@ -1829,29 +1866,46 @@ final class CompletionCoordinator {
         // plus the prefix at top priority so it survives a tight budget. Priorities set the FILL order
         // (prefix first, OCR last); the allocator trims/drops lowest-priority blocks to fit totalChars.
         var sections: [PromptSection] = []
-        func addContext(_ s: String?, priority: Int) {
+        func addContext(_ s: String?, name: String = "ctx", priority: Int) {
             guard let s, !s.isEmpty else { return }
             // maxChars is a BYTE budget (PromptSectionBudget costs in UTF-8 bytes); each section's own
             // max is its full byte length so it's only trimmed when the TOTAL budget binds.
-            sections.append(PromptSection(name: "ctx", content: s, priority: priority,
+            sections.append(PromptSection(name: name, content: s, priority: priority,
                                           minChars: 0, maxChars: PromptSectionBudget.cost(s),
                                           truncation: .preserveEnd))
         }
         if isLicensed { addContext(instruction, priority: 80) }              // FR-PA-3 (paid)
         if isLicensed && styleEnabled { addContext(styleHint, priority: 60) } // FR-CTX-3 (paid)
         if isLicensed && clipboardEnabled { addContext(clipboard, priority: 40) } // FR-CTX-2 (paid)
-        if ocrEnabled { addContext(ocr, priority: 20) }                     // FR-CTX-1 (FREE)
-        // The prefix (kept nearest-the-caret tail) — top priority, never starved.
-        let prefixSection = PromptSection(name: "prefix", content: prefix, priority: 1000,
-                                          minChars: 0, maxChars: PromptSectionBudget.cost(prefix),
+        if ocrEnabled { addContext(ocr, name: "ocr", priority: 20) }         // FR-CTX-1 (FREE)
+        // The prefix (kept nearest-the-caret tail) — top priority, so it still wins under contention, but
+        // CAPPED so it can't take the whole budget. It used to declare its own full length as maxChars:
+        // the allocator fills highest-priority first, so any draft longer than the budget consumed 100% of
+        // it, every context block then trimmed to "" and was dropped, and the caller silently got the BARE
+        // prefix — instruction, style, clipboard and OCR vanished in any document past the budget, with no
+        // log and nothing visible to the user. 65% leaves the context blocks reserved room while keeping
+        // the caret text dominant; the prefix still keeps its tail (nearest the caret) when trimmed.
+        // ...but ONLY when there is context to reserve room for. With no blocks (the Free default: no
+        // licence, OCR off) a 65% cap would shrink the caret window for nothing — wasting a third of the
+        // budget AND starting the sliding truncation below a third earlier than the engine's own cap would.
+        let prefixCap = sections.isEmpty ? totalChars : max(1, totalChars / 100 * 65)
+        // Anchored so the kept window's START holds still across a typing burst. A plain tail cut slides one
+        // byte per keystroke, which diverges the prompt at its first token and costs a full cold re-prefill
+        // every fire (see PromptSectionBudget.anchoredTail). Pre-windowed here, so the section declares its
+        // own already-fitting length and the allocator never re-cuts it unanchored.
+        let windowedPrefix = PromptSectionBudget.anchoredTail(prefix, maxCost: prefixCap)
+        let prefixSection = PromptSection(name: "prefix", content: windowedPrefix, priority: 1000,
+                                          minChars: 0,
+                                          maxChars: PromptSectionBudget.cost(windowedPrefix),
                                           truncation: .preserveEnd)
         sections.append(prefixSection)
 
         let allocated = PromptSectionBudget.allocate(sections, totalChars: totalChars)
         let outPrefix = allocated.first(where: { $0.name == "prefix" })?.content ?? prefix
-        let blocks = allocated.filter { $0.name == "ctx" }.map(\.content)
+        let blocks = allocated.filter { $0.name != "prefix" }.map(\.content)
+        let ocrKept = allocated.contains { $0.name == "ocr" }
 
-        guard !blocks.isEmpty else { return outPrefix }
+        guard !blocks.isEmpty else { return (outPrefix, ocrKept) }
         // Document-shaped framing: a base (pretrained) model follows the `Header:\n…` pattern from its
         // corpus, so labelling the blocks as `Context:` demotes them to reference material and the
         // `Text:` marker tells the model the prefix is the live text to CONTINUE conditioned on that
@@ -1865,7 +1919,7 @@ final class CompletionCoordinator {
         // `Text:` marker, byte-identical to the pre-steer output. The name derives from the cached
         // context, so it's stable across a burst (KV warm path preserved).
         let textMarker = steerLanguageName.map { "\n\nText (in \($0)):\n" } ?? "\n\nText:\n"
-        return "Context:\n" + blocks.joined(separator: "\n\n") + textMarker + outPrefix
+        return ("Context:\n" + blocks.joined(separator: "\n\n") + textMarker + outPrefix, ocrKept)
     }
 
     // MARK: - Shell-command framing (terminal shell-command mode)

--- a/Sources/Shadowtype/CompletionCoordinator.swift
+++ b/Sources/Shadowtype/CompletionCoordinator.swift
@@ -17,12 +17,22 @@ enum WordCap {
 }
 
 final class CompletionCoordinator {
-    // Confidence-gating thresholds (see ConfidenceGate). Conservative defaults tuned to drop obvious
-    // word-salad without eating good suggestions; override at runtime via env for live tuning.
+    // Confidence-gating thresholds (see ConfidenceGate), expressed in RAW top-1 probability — the
+    // model's own softmax peak, not the post-sampler-chain peak these numbers were originally read
+    // against. That old number was inflated ~5× (top_k 40 truncation + top_p 0.9 truncate-renormalize +
+    // temp 0.4 sharpening), so 0.10/0.08 really meant ~0.02/0.016 on the model's own scale and neither
+    // gate ever fired. Re-derived for the raw scale: the first CONTENT token sits at a word boundary,
+    // the highest-entropy position in next-token prediction, where a perfectly good continuation
+    // routinely peaks at only 0.10–0.25 — so a 0.10 raw floor would eat good suggestions. Below 0.05 the
+    // mass is spread over 20+ near-equal candidates: the flat distribution word-salad comes out of. The
+    // running mean sits lower (0.03) because it mixes those hard word-start tokens with easy intra-word
+    // continuations (often > 0.9), so it only trips on a completion that genuinely came apart — and
+    // because a false mean reject truncates a ghost the user may already be reading. Override at runtime
+    // via env for live tuning.
     static let firstTokenMinProb: Double =
-        envDouble("SHADOWTYPE_GATE_FIRST") ?? 0.10
+        envDouble("SHADOWTYPE_GATE_FIRST") ?? 0.05
     static let meanMinProb: Double =
-        envDouble("SHADOWTYPE_GATE_MEAN") ?? 0.08
+        envDouble("SHADOWTYPE_GATE_MEAN") ?? 0.03
 
     private static func envDouble(_ key: String) -> Double? {
         ProcessInfo.processInfo.environment[key].flatMap(Double.init)
@@ -156,6 +166,16 @@ final class CompletionCoordinator {
     // command substitution, `*` = glob, leading `-` = flag) — and instead runs only a newline truncation
     // plus the destructive-command guard. Set per generation in startGeneration / the history fast path.
     private var generationShellMode = false
+
+    // True once the CURRENT generation has actually painted a ghost. renderSuggestion runs per streamed
+    // snapshot and its reject filters are evaluated on PARTIAL text, where none of them is monotonic: a
+    // two-word intermediate like "the the" satisfies the self-repetition rule, and NLLanguageRecognizer
+    // on a 6-character string is a coin flip. Re-running them per snapshot could therefore take a ghost
+    // back off screen that the previous snapshot put there — a show → vanish → show flash, precisely the
+    // flicker the confidence gate refuses to cause. Once this is set, a reject STOPS further renders
+    // instead of retracting (see rejectRender). Reset in bumpGeneration (a superseded generation's ghost
+    // is no longer protected) and in clearSuggestion (nothing on screen to protect).
+    private var generationCommitted = false
 
     // Cached writing-style hint (FR-CTX-3). Like the OCR cache, this is refreshed ONLY on focus-in (the
     // cold path), NOT per keystroke: the profile only changes on a Tab-accept, and recomputing it inside
@@ -729,7 +749,7 @@ final class CompletionCoordinator {
         // on a hit, render it verbatim without ever touching the model. Secret-bearing matches are dropped
         // (never surface a token/password as a ghost), and the danger guard still applies.
         if shellMode, let buffer = shellBuffer {
-            let current = Self.shellCurrentLine(prefix)
+            let current = Self.shellTypedCommand(prefix)
             if let remainder = ShellHistory.prefixMatch(currentLine: current, buffer: buffer),
                !remainder.isEmpty {
                 let full = current + remainder
@@ -899,6 +919,24 @@ final class CompletionCoordinator {
                         Diag.log("gen: low first-token confidence first=\(gate.firstProbString) -> hide")
                         return false
                     }
+                    // Running mean gate — the word-salad backstop. It used to be evaluated only AFTER the
+                    // whole decode and then refused to hide anything already on screen; since the first
+                    // content token renders synchronously and unconditionally, "already on screen" was
+                    // every path that had text to reject, so the branch was structurally unreachable and
+                    // the backstop had never fired once. Checked per token instead. `gate` already
+                    // includes THIS token (the engine calls onSample before onToken), so returning false
+                    // here drops the flailing token and everything after it, leaving the ghost rendered
+                    // up to the previous token exactly as it is.
+                    // TRADEOFF (deliberate): this SHORTENS a collapsing completion rather than
+                    // suppressing it. The two alternatives each break a harder rule — retracting the
+                    // visible ghost is the show→vanish flicker this file refuses to cause anywhere else,
+                    // and withholding the first render for a few tokens costs first-appearance latency,
+                    // which is the product. Cutting at the collapse point costs neither, and with the
+                    // first-token gate now working on real probabilities it is the cheap half of the job.
+                    if gate.meanRejected {
+                        Diag.log("gen: mean confidence collapsed mean=\(gate.meanProbString) -> stop (kept rendered ghost)")
+                        return false
+                    }
                     acc += piece
                     let snapshot = acc
                     // Stop sequence: once a paragraph break (`\n\n`) follows real content, the base model
@@ -996,21 +1034,10 @@ final class CompletionCoordinator {
                         Diag.log("gen: refire divergent -> discard (kept visible ghost)")
                     }
                 }
-                // Cumulative confidence gate: a completion whose mean token probability is poor reads as
-                // word-salad even when each guard above passed; drop it (FR — fewer incoherent ghosts).
-                // BUT: never yank a ghost the user is already reading. The mean-reject fires after the
-                // full decode, by which point the first-token render at line ~822 may have already
-                // committed a partial ghost. Hiding it now is a visible "show → vanish" flash the user
-                // perceives as flicker (worse UX than a slightly garbled completion). So the hide only
-                // applies when nothing has been committed to screen yet.
-                if self.isCurrent(myGen) && !acc.isEmpty && finalGate.meanRejected {
-                    if self.suggestionVisible && !self.suggestionText.isEmpty {
-                        Diag.log("gen: low mean confidence mean=\(finalGate.meanProbString) -> kept visible ghost")
-                    } else {
-                        Diag.log("gen: low mean confidence mean=\(finalGate.meanProbString) -> hide")
-                        self.clearSuggestion(); return
-                    }
-                }
+                // No post-decode confidence check here on purpose: the cumulative mean gate that used to
+                // live at this point could only ever hide a ghost that had NOT been committed to screen,
+                // and by the time this runs the first-token render always has — it was dead code. The
+                // mean gate now runs per token inside onToken above, where it can still stop the decode.
                 // If the stream produced nothing and is still current, hide.
                 if self.isCurrent(myGen) && acc.isEmpty { Diag.log("gen: produced nothing (deadline/EOG)"); self.clearSuggestion() }
                 else if self.isCurrent(myGen) { Diag.log("gen: done len=\(acc.count) mean=\(finalGate.meanProbString)"); Diag.logContent("gen: done acc=\"\(acc.prefix(40))\"") }
@@ -1257,6 +1284,21 @@ final class CompletionCoordinator {
         return CGRect(x: x, y: base.minY, width: 0, height: base.height)
     }
 
+    // A reject verdict for the CURRENT snapshot. Before this generation committed a ghost, hide (there is
+    // nothing on screen to protect, so the old behaviour is exactly right). After, keep what the user is
+    // already reading and merely stop repainting: the filters are non-monotonic, so a later snapshot may
+    // well pass again, and retract-then-restore is the worst-looking of the three outcomes. A held
+    // context re-fire counts as committed too — the visible ghost there belongs to a deliberately held
+    // earlier generation the re-fire is contractually forbidden to replace.
+    private func rejectRender(_ reason: String) {
+        if (generationCommitted || inContextRefire), suggestionVisible, !suggestionText.isEmpty {
+            Diag.log("render: \(reason) -> stop (kept visible ghost)")
+            return
+        }
+        Diag.log("render: \(reason) -> hide")
+        clearSuggestion()
+    }
+
     private func renderSuggestion(_ rawText: String, checkPrefixDup: Bool = true, caretOverride: CGRect? = nil) {
         // Rising edge: a fresh completion (not the streamed re-render of a growing ghost, nor the
         // remainder re-render after a word accept — both keep the ghost already-visible). Drives the
@@ -1271,17 +1313,22 @@ final class CompletionCoordinator {
             // Shell-command mode: bypass EVERY prose transform — markup strip (backticks = command
             // substitution), list-marker strip (leading `-` = flag), glue/leading-space reconcile, and the
             // language guards all corrupt shell syntax. Keep exactly one line, then apply the destructive-
-            // command guard on the JOINED command (typed current line + suggestion) so a split `rm -rf ` +
-            // `/` is still caught.
+            // command guard on the JOINED command (the typed command with the prompt chrome stripped, plus
+            // the suggestion) so a split `rm -rf ` + `/` is still caught.
             text = Self.truncatedAtNewline(rawText)
-            let fullCommand = Self.shellCurrentLine(activePrefix) + text
+            let fullCommand = Self.shellTypedCommand(activePrefix) + text
+            // The ONE reject that keeps the right to retract a committed ghost. Every other filter here
+            // is a quality judgement whose worst case is a slightly worse suggestion, so it defers to the
+            // no-flicker rule; this one is a safety judgement whose worst case is irreversible (`rm -rf `
+            // is harmless until ` /` streams in, and the ghost is one Tab from being typed). A one-frame
+            // flash on the rare hit is the cheaper side of that trade — and the guard is deliberately
+            // narrow, so it is genuinely rare.
             if ShellCommandGuard.isDangerous(fullCommand: fullCommand) {
                 Diag.log("render: dangerous command -> hide")
                 clearSuggestion(); return
             }
             guard text.contains(where: { !$0.isWhitespace }) else {
-                Diag.log("render: shell empty -> hide")
-                clearSuggestion(); return
+                rejectRender("shell empty"); return
             }
         } else {
         text = Self.truncatedAtParagraphBreak(
@@ -1299,22 +1346,19 @@ final class CompletionCoordinator {
         if prefixTransforms { text = applyGlueGuard(text, prefix: activePrefix) }
         if prefixTransforms { text = Self.reconcileLeadingSpace(suggestion: text, prefix: activePrefix) }
         guard !text.isEmpty, !Self.isLowValueSuggestion(text) else {
-            Diag.log("render: low-value -> hide")
-            clearSuggestion(); return
+            rejectRender("low-value"); return
         }
         // Suppress a completion that just loops back over text already typed ("thanks for " +
         // "for reading" -> stutter on inject). Skipped on the accept-remainder re-render, whose
         // `activePrefix` is stale (the accepted word isn't folded into it).
         if prefixTransforms, Self.isPrefixDuplicate(suggestion: text, prefix: activePrefix) {
-            Diag.log("render: prefix-duplicate -> hide")
-            clearSuggestion(); return
+            rejectRender("prefix-duplicate"); return
         }
         // Language-drift guard: a base model sometimes switches language mid-stream (an English ghost in a
         // Spanish doc). Suppress only on a confident, clearly-different language read (skip on the stale
         // remainder re-render). Conservative — never fires on a short/ambiguous prefix.
         if prefixTransforms, Self.languageDrifts(prefix: activePrefix, suggestion: text) {
-            Diag.log("render: lang-drift -> hide")
-            clearSuggestion(); return
+            rejectRender("lang-drift"); return
         }
         // Context-language guard: when the surrounding conversation has a confident dominant language,
         // suppress a completion that drifts to a DIFFERENT language (a base model following the
@@ -1324,16 +1368,14 @@ final class CompletionCoordinator {
         // long + high-confidence. Skipped on the stale accept-remainder re-render.
         if prefixTransforms, let target = generationContextLang,
            Self.suggestionConflictsWithContext(suggestion: text, contextLang: target) {
-            Diag.log("render: context-lang conflict -> hide")
-            clearSuggestion(); return
+            rejectRender("context-lang conflict"); return
         }
         }
         // Drop leading newlines (the model often "ends" the line then starts a template) and require
         // at least one printable char — otherwise the ghost would render as invisible whitespace.
         let display = String(text.drop(while: { $0 == "\n" || $0 == "\r" }))
         guard display.contains(where: { !$0.isWhitespace }) else {
-            Diag.log("render: blank/whitespace-only -> hide")
-            clearSuggestion(); return
+            rejectRender("blank/whitespace-only"); return
         }
         let opacity = capOpacity() ?? 1
         suggestionText = text
@@ -1365,6 +1407,7 @@ final class CompletionCoordinator {
             wordMeter?.recordSuggestionShown()
         }
         suggestionVisible = true
+        generationCommitted = true
         // Cotypist-pattern coexistence nudge for Gmail's Smart Compose. Gated by the per-session/
         // dismiss pre-gate before any AX read so the steady state (already prompted or dismissed) is
         // free. See SmartComposeNudge for the detection heuristic.
@@ -1469,6 +1512,7 @@ final class CompletionCoordinator {
         pendingStreamWork = nil
         pendingStreamSnapshot = nil
         suggestionVisible = false   // didSet notifies the Tab swallow only on transition
+        generationCommitted = false // nothing on screen → the next reject may hide freely
     }
 
     // MARK: - Host font watch (FR-OV-4)
@@ -1842,7 +1886,7 @@ final class CompletionCoordinator {
     // defaults to "unbounded" so existing callers/tests keep the exact prior behavior; the live caller
     // passes a finite budget so a noisy screen capture can't crowd out the caret text or blow the
     // context window (#8 PromptSectionBudget). The prefix is given top fill-priority and is never
-    // dropped — the lower-priority context blocks (OCR first, then clipboard, style, instruction) trim
+    // dropped — the lower-priority context blocks (style first, then OCR, clipboard, instruction) trim
     // or drop to fit — but it is itself capped at a share of the budget so it can't drop ALL of them
     // (see prefixCap below). Surviving blocks keep their original render order.
     // Returns the prompt plus whether the OCR block survived the budget, which the caller needs to decide
@@ -1864,20 +1908,37 @@ final class CompletionCoordinator {
 
         // Build the gated context sections in render order (instruction → style → clipboard → OCR),
         // plus the prefix at top priority so it survives a tight budget. Priorities set the FILL order
-        // (prefix first, OCR last); the allocator trims/drops lowest-priority blocks to fit totalChars.
+        // (prefix first, style last); the allocator trims/drops lowest-priority blocks to fit totalChars.
         var sections: [PromptSection] = []
-        func addContext(_ s: String?, name: String = "ctx", priority: Int) {
+        // `directive` marks a block whose MEANING LIVES IN ITS WORDING — the user's instruction and the
+        // style hint. Trimming those doesn't degrade them, it changes them: "Always reply in formal
+        // Spanish, never use contractions" cut to its tail is the different instruction "never use
+        // contractions", and the style hint cut anywhere loses the explanatory label that makes its word
+        // list interpretable at all, leaving a bare semicolon list the model reads as content to copy. So
+        // a directive declares minChars == its full cost: the allocator takes it WHOLE or drops it.
+        // `.preserveStart` is the matching end (the head carries the directive's subject) — with the
+        // all-or-nothing minChars it never actually trims, but `.preserveEnd` here would be wrong the
+        // moment either number moves. The prose blocks (clipboard, OCR) keep `.preserveEnd`/minChars 0:
+        // their tail is the part nearest the caret and a fragment of it is still useful context.
+        func addContext(_ s: String?, name: String = "ctx", priority: Int, directive: Bool = false) {
             guard let s, !s.isEmpty else { return }
             // maxChars is a BYTE budget (PromptSectionBudget costs in UTF-8 bytes); each section's own
             // max is its full byte length so it's only trimmed when the TOTAL budget binds.
+            let cost = PromptSectionBudget.cost(s)
             sections.append(PromptSection(name: name, content: s, priority: priority,
-                                          minChars: 0, maxChars: PromptSectionBudget.cost(s),
-                                          truncation: .preserveEnd))
+                                          minChars: directive ? cost : 0, maxChars: cost,
+                                          truncation: directive ? .preserveStart : .preserveEnd))
         }
-        if isLicensed { addContext(instruction, priority: 80) }              // FR-PA-3 (paid)
-        if isLicensed && styleEnabled { addContext(styleHint, priority: 60) } // FR-CTX-3 (paid)
-        if isLicensed && clipboardEnabled { addContext(clipboard, priority: 40) } // FR-CTX-2 (paid)
-        if ocrEnabled { addContext(ocr, name: "ocr", priority: 20) }         // FR-CTX-1 (FREE)
+        // Priority is the FILL order — the reverse of the DROP order — and is independent of the render
+        // order below (PromptSectionBudget.allocate returns survivors in their original array order), so
+        // these numbers can be reasoned about on usefulness alone. Style is now the FIRST block dropped,
+        // below screen context: a vocabulary hint nudges word choice, while the screen text is what the
+        // next word is actually ABOUT. At its old 60 it outranked both clipboard and OCR and starved the
+        // far more informative context whenever the budget bound.
+        if isLicensed { addContext(instruction, priority: 80, directive: true) }   // FR-PA-3 (paid)
+        if isLicensed && styleEnabled { addContext(styleHint, priority: 10, directive: true) } // FR-CTX-3 (paid)
+        if isLicensed && clipboardEnabled { addContext(clipboard, priority: 40) }  // FR-CTX-2 (paid)
+        if ocrEnabled { addContext(ocr, name: "ocr", priority: 20) }               // FR-CTX-1 (FREE)
         // The prefix (kept nearest-the-caret tail) — top priority, so it still wins under contention, but
         // CAPPED so it can't take the whole budget. It used to declare its own full length as maxChars:
         // the allocator fills highest-priority first, so any draft longer than the budget consumed 100% of
@@ -1936,10 +1997,12 @@ final class CompletionCoordinator {
     //
     // The header + exemplar block is byte-stable across a typing burst at one prompt (only the tail token
     // grows), so the engine's KV warm path (FR-CE-5) is preserved. `prefix` is the forward-from-caret tail;
-    // its OWN current line (after the last newline) becomes the typed command — earlier prefix lines are
-    // ignored in favour of the richer buffer exemplars.
+    // its OWN current line, with the prompt chrome stripped (shellTypedCommand), becomes the typed command
+    // — earlier prefix lines are ignored in favour of the richer buffer exemplars.
     static func assembleShellPrompt(prefix: String, terminalBuffer: String?, totalChars: Int = 4000) -> String {
-        let typed = trimmingTrailingInlineWhitespace(shellCurrentLine(prefix))
+        // Redacted like the exemplars are: a secret the user is typing RIGHT NOW is the one most worth not
+        // handing to the model, and it used to be the only part of the prompt that went in verbatim.
+        let typed = redactingSecrets(trimmingTrailingInlineWhitespace(shellTypedCommand(prefix)))
         var lines: [String] = []
         if let header = shellContextHeader(terminalBuffer) { lines.append(header) }
         // Recent commands as few-shot exemplars (redacted). Drop any that equal the typed stem so the model
@@ -1960,12 +2023,36 @@ final class CompletionCoordinator {
         return head + "$ " + typed
     }
 
-    // The current command line being typed: the tail of `prefix` after the last newline.
+    // The current command line being typed: the tail of `prefix` after the last newline. RAW — in a
+    // terminal it still carries the live PS1. Consumers want shellTypedCommand below.
     static func shellCurrentLine(_ prefix: String) -> String {
         if let nl = prefix.lastIndex(where: { $0 == "\n" || $0 == "\r" }) {
             return String(prefix[prefix.index(after: nl)...])
         }
         return prefix
+    }
+
+    // The command the user is TYPING: the current line with the terminal's prompt chrome stripped
+    // (`dario@mac ~/proj % git pu` -> `git pu`), using the same sigil rule that made this a shell prompt
+    // in the first place (ActivationPolicy.isShellPromptLine / shellCommandAfterSigil).
+    //
+    // Every consumer of the current line used to get the RAW line, chrome and all, which broke all three:
+    // assembleShellPrompt emitted `$ dario@mac ~/proj % git pu` as its continuation line — not
+    // command-shaped, and duplicating the stem the exemplars already end with; ShellHistory.prefixMatch
+    // compared that chrome-laden stem against chrome-STRIPPED history commands, so the zero-hallucination
+    // fast path could never hit; and the destructive-command guard tokenized `dario@mac …` and saw a
+    // first token that is not `rm`, so `rm -rf /` sailed straight through it.
+    //
+    // Falls back to the raw line when it carries no sigil (some terminals expose only the typed text —
+    // that is the shape every existing test uses). Trailing whitespace is deliberately PRESERVED:
+    // shellCommandAfterSigil trims both ends, but a typed `git ` must complete to `status`, not
+    // ` status`, and the guard must see the space in `rm -rf ` + `/`.
+    static func shellTypedCommand(_ prefix: String) -> String {
+        let line = shellCurrentLine(prefix)
+        guard let cmd = shellCommandAfterSigil(line) else { return line }
+        // Chrome only (`~/proj $ `) → no typed command yet.
+        guard !cmd.isEmpty, let r = line.range(of: cmd, options: .backwards) else { return "" }
+        return String(line[r.lowerBound...])
     }
 
     // Pure: pull recent COMMAND text (not output) from the visible buffer — the lines that carry a shell
@@ -2419,6 +2506,9 @@ final class CompletionCoordinator {
     private func bumpGeneration() -> Int {
         genLock.lock(); defer { genLock.unlock() }
         generation += 1
+        // A new generation owns the ghost from here on: whatever is still on screen belongs to the
+        // superseded one, so its render-reject latch (see rejectRender) no longer protects it.
+        generationCommitted = false
         return generation
     }
 

--- a/Sources/Shadowtype/ConfidenceGate.swift
+++ b/Sources/Shadowtype/ConfidenceGate.swift
@@ -1,10 +1,13 @@
 // ConfidenceGate — pure, testable accumulator for suppressing low-confidence completions.
-// The inference engine reports each content token's post-sampler probability; this gate turns the
-// stream of probabilities into two suppression decisions:
+// The inference engine reports each content token's RAW top-1 probability — the model's own softmax
+// peak, BEFORE the sampler chain reshapes the distribution (see InferenceEngine.sampleWithProb). This
+// gate turns the stream of probabilities into two suppression decisions:
 //   • firstTokenRejected — the model was already unsure on its FIRST content token (gate before any
 //     render, so nothing flashes on screen).
-//   • meanRejected — the geometric-mean probability across the whole completion is poor, i.e. the
-//     model was flailing and produced word-salad even if every structural filter passed.
+//   • meanRejected — the RUNNING geometric-mean probability has collapsed, i.e. the model started
+//     flailing mid-completion and is producing word-salad even though every structural filter passed.
+//     Read PER TOKEN so the decode can be cut at the collapse point; the ghost already on screen is
+//     never retracted (see CompletionCoordinator.startGeneration for that tradeoff).
 // Geometric mean (exp of mean log-prob) is the natural aggregate: it is the inverse of perplexity and
 // punishes a single near-zero token instead of letting a few confident tokens mask it.
 import Foundation
@@ -40,7 +43,11 @@ struct ConfidenceGate {
         return p < firstTokenMinProb
     }
 
-    var meanRejected: Bool { count > 0 && meanProb < meanMinProb }
+    // Needs a SECOND sample to mean anything: with one token the geometric mean IS that token's
+    // probability, so a count-of-1 check would silently re-decide the first token at the mean's (looser)
+    // threshold instead of the first-token gate's. From token 2 on it measures what it is meant to —
+    // whether the completion is holding together or coming apart.
+    var meanRejected: Bool { count >= 2 && meanProb < meanMinProb }
 
     // Compact log strings (avoid leaking full precision into Diag lines).
     var firstProbString: String { firstProb.map { String(format: "%.3f", $0) } ?? "nil" }

--- a/Sources/Shadowtype/EditContextTracker.swift
+++ b/Sources/Shadowtype/EditContextTracker.swift
@@ -88,7 +88,17 @@ final class EditContextTracker {
     }
 
     func currentPrefix() -> String? {
-        return resolvePrefix().map(Self.normalizingSpaces)
+        return resolveTextAroundCaret()?.prefix
+    }
+
+    // Text AFTER the caret (first `maxChars` UTF-16 units, itself clamped by the maxSuffixChars hard
+    // cap), or nil when the field/caret can't be resolved, the field is secure, or nothing follows the
+    // caret. Free on the native path — it comes from the SAME kAXValue + caret offset the prefix read
+    // already fetched, no second AX round trip — and nil on every web/text-marker host (see CaretText).
+    // Sanitized exactly like the prefix: a secure field never yields one, and the NBSP family is folded.
+    func suffixAfterCaret(maxChars: Int = EditContextTracker.maxSuffixChars) -> String? {
+        guard let s = resolveTextAroundCaret()?.suffix else { return nil }
+        return Self.suffixAfterCaret(s, caret: 0, maxChars: maxChars)
     }
 
     // WebKit contenteditable (Apple Mail's compose, web mail) stores a significant trailing/embedded
@@ -110,51 +120,67 @@ final class EditContextTracker {
         "\u{2007}",  // FIGURE SPACE
     ]
 
-    private func resolvePrefix() -> String? {
+    // How much post-caret text we ever read. One screenful is ample to notice that a completion would
+    // duplicate or contradict what already follows the caret, and the cap keeps a 100k-char document
+    // from being copied out of AX on every keystroke.
+    static let maxSuffixChars = 400
+
+    // Text on BOTH sides of the caret, from ONE AX read.
+    private struct CaretText {
+        let prefix: String
+        // Post-caret text (capped at maxSuffixChars), nil when nothing follows the caret OR the read
+        // path can't see past it. Only the native kAXValue+range paths can: on a web/text-marker host
+        // the suffix would cost a whole SECOND marker chain per keystroke (doc-end marker + range build
+        // + stringify) on top of the prefix's, and a correct nil beats an expensive-or-wrong suffix.
+        let suffix: String?
+    }
+
+    // Negative read cache: the focus generation + element + the character count the element reported at
+    // the moment the read failed. A hollow focus (a real diag showed role=AXWindow, descend=AXSplitter,
+    // prefix=nil) used to re-walk the entire tree — descend BFS, marker chains, index probes — on EVERY
+    // keystroke: ~14 walks in 130 ms, all nil. Keyed on focusChangeSequence so a different focused
+    // element always re-probes from scratch. TWO guards keep it from latching a field that is actually
+    // usable: (a) the character count — a field that is merely EMPTY right now (an empty Apple Mail
+    // compose genuinely fails the read) must become readable the instant the user types, so any change
+    // in the count busts the cache; (b) lastGoodReadFocusSeq — a focus that has ALREADY yielded text
+    // this session is never cached, because a nil there is the transient redraw flicker that
+    // FocusCapabilityFlickerGate exists for (Apple Calendar's editor), not a dead field.
+    // Side benefit: throttles the diag below from once-per-keystroke to once per (focus, content) state.
+    private var prefixFailure: (seq: UInt64, element: AXUIElement, chars: Int)?
+    // Focus generation whose text we last read successfully — guard (b) above.
+    private var lastGoodReadFocusSeq: UInt64?
+
+    private func resolveTextAroundCaret() -> CaretText? {
         guard let element = currentFocusedElement(), !isSecure(element) else { return nil }
+        return resolveTextAroundCaret(of: element)
+    }
 
-        // (1) Native path: kAXValue + kAXSelectedTextRange (Cocoa/AppKit fields).
-        if let caret = caretLocation(of: element), let text = elementString(element) {
-            let p = prefixBeforeCaret(text, caret: caret)
-            Diag.log("prefix: ok via=native len=\(p.utf16.count) role=\(roleSubrole(element))")
-            return p
+    // `preDescended`: pass `.some(…)` when the caller already resolved descendToEditable (a
+    // FocusSnapshot has) so the BFS isn't repeated; the default resolves it lazily, and only if the
+    // direct paths fail.
+    private func resolveTextAroundCaret(of element: AXUIElement,
+                                        descended preDescended: AXUIElement?? = nil) -> CaretText? {
+        // Known-bad focus: one cheap attribute read decides whether anything changed (see prefixFailure).
+        if let f = prefixFailure, f.seq == focusChangeSequence, cfEqual(f.element, element) {
+            if (characterCount(of: element) ?? -1) == f.chars { return nil }
+            prefixFailure = nil
+        }
+        if let text = readTextAroundCaret(of: element, descended: preDescended) {
+            lastGoodReadFocusSeq = focusChangeSequence
+            return text
         }
 
-        // (2) Web/Electron/Chromium path (Slack/Warp/VS Code): text-marker string before the caret
-        // (PRD R2). Read forward-from-caret only — webPrefix is document-start→caret (FR-KC-2).
-        if let webText = AXTextProbe.webPrefix(of: element) {
-            Diag.log("prefix: ok via=web len=\(webText.utf16.count) role=\(roleSubrole(element))")
-            return webText
+        // (4) Give up gracefully rather than feed the model wrong text, and remember the failure for this
+        // focus generation so the walk above isn't repeated per keystroke — unless this focus has already
+        // read fine once, in which case the nil is a flicker (see prefixFailure guard (b)). The per-step
+        // marker probe, index probe and full attribute dump are AX-IPC heavy, so build them ONLY when
+        // diag is enabled — in a shipping build (diag off) the eagerly-built Diag.log argument would
+        // otherwise still pay for them.
+        if lastGoodReadFocusSeq != focusChangeSequence {
+            prefixFailure = (focusChangeSequence, element, characterCount(of: element) ?? -1)
         }
-
-        // (3) Descend to the real editable text node and retry the native path on it.
-        let descended = AXTextProbe.descendToEditable(element)
-        if let editable = descended, !isSecure(editable) {
-            if let caret = caretLocation(of: editable), let text = elementString(editable) {
-                let p = prefixBeforeCaret(text, caret: caret)
-                Diag.log("prefix: ok via=descend-native len=\(p.utf16.count) role=\(roleSubrole(editable))")
-                return p
-            }
-            if let webText = AXTextProbe.webPrefix(of: editable) {
-                Diag.log("prefix: ok via=descend-web len=\(webText.utf16.count) role=\(roleSubrole(editable))")
-                return webText
-            }
-        }
-
-        // (3.5) Position-derived marker prefix: modern Apple Mail's compose AXWebArea omits
-        // AXStartTextMarkerForTextMarkerRange (so the marker chain in webPrefix dead-ends) but DOES
-        // answer the caret bounds, AXTextMarkerForPosition, AXStartTextMarker and the unordered-range
-        // builder. Derive the caret marker from its on-screen point and read document-start→caret.
-        if let s = AXTextProbe.webPrefixViaPosition(of: element), !s.isEmpty {
-            Diag.log("prefix: ok via=web-position len=\(s.utf16.count) role=\(roleSubrole(element))")
-            return s
-        }
-
-        // (4) Give up gracefully rather than feed the model wrong text. The per-step marker probe, index
-        // probe and full attribute dump are AX-IPC heavy, so build them ONLY when diag is enabled — on a
-        // permanently-unreadable host (Google Docs canvas) this branch fires every keystroke, and in a
-        // shipping build (diag off) the eagerly-built Diag.log argument would otherwise still pay for them.
         if Diag.isEnabled {
+            let descended = preDescended ?? AXTextProbe.descendToEditable(element)
             Diag.log("prefix: nil role=\(roleSubrole(element)) web=\(AXTextProbe.webPrefixFailureStep(of: element)) idx=[\(AXTextProbe.indexCapabilities(of: element))] descend=\(descended.map { roleSubrole($0) } ?? "none") url=\(frontmostDomainHost() ?? "?")")
             // One-shot per focus session: dump the full AX attribute surface of the focused element, its
             // descended node, and its ancestors — the supported-attribute lists reveal which read path a
@@ -164,6 +190,49 @@ final class EditContextTracker {
                 dumpAXAttributes(element, descended: descended)
             }
         }
+        return nil
+    }
+
+    // The read itself, in resolution order. nil = no path could see the caret's text.
+    private func readTextAroundCaret(of element: AXUIElement,
+                                     descended preDescended: AXUIElement??) -> CaretText? {
+        // (1) Native path: kAXValue + kAXSelectedTextRange (Cocoa/AppKit fields).
+        if let caret = caretLocation(of: element), let text = elementString(element) {
+            let t = caretText(text, caret: caret)
+            Diag.log("prefix: ok via=native len=\(t.prefix.utf16.count) role=\(roleSubrole(element))")
+            return t
+        }
+
+        // (2) Web/Electron/Chromium path (Slack/Warp/VS Code): text-marker string before the caret
+        // (PRD R2). Read forward-from-caret only — webPrefix is document-start→caret (FR-KC-2).
+        if let webText = AXTextProbe.webPrefix(of: element) {
+            Diag.log("prefix: ok via=web len=\(webText.utf16.count) role=\(roleSubrole(element))")
+            return CaretText(prefix: Self.normalizingSpaces(webText), suffix: nil)
+        }
+
+        // (3) Descend to the real editable text node and retry the native path on it.
+        let descended = preDescended ?? AXTextProbe.descendToEditable(element)
+        if let editable = descended, !isSecure(editable) {
+            if let caret = caretLocation(of: editable), let text = elementString(editable) {
+                let t = caretText(text, caret: caret)
+                Diag.log("prefix: ok via=descend-native len=\(t.prefix.utf16.count) role=\(roleSubrole(editable))")
+                return t
+            }
+            if let webText = AXTextProbe.webPrefix(of: editable) {
+                Diag.log("prefix: ok via=descend-web len=\(webText.utf16.count) role=\(roleSubrole(editable))")
+                return CaretText(prefix: Self.normalizingSpaces(webText), suffix: nil)
+            }
+        }
+
+        // (3.5) Position-derived marker prefix: modern Apple Mail's compose AXWebArea omits
+        // AXStartTextMarkerForTextMarkerRange (so the marker chain in webPrefix dead-ends) but DOES
+        // answer the caret bounds, AXTextMarkerForPosition, AXStartTextMarker and the unordered-range
+        // builder. Derive the caret marker from its on-screen point and read document-start→caret.
+        if let s = AXTextProbe.webPrefixViaPosition(of: element), !s.isEmpty {
+            Diag.log("prefix: ok via=web-position len=\(s.utf16.count) role=\(roleSubrole(element))")
+            return CaretText(prefix: Self.normalizingSpaces(s), suffix: nil)
+        }
+
         return nil
     }
 
@@ -206,8 +275,31 @@ final class EditContextTracker {
     /// per-app "mid-line completions" gate. Best-effort: only the native value+range path can see
     /// post-caret text; the web/marker path (prefix-only) returns true so we never suppress on a
     /// surface where we genuinely can't tell (preserves current behavior there).
+    /// NOT an end-of-DOCUMENT test: it looks at exactly one character ahead, so it is true with three
+    /// more paragraphs below the caret. Use suffixAfterCaret() to know what actually follows.
     func caretAtLineEnd() -> Bool {
         guard let element = currentFocusedElement(), !isSecure(element) else { return true }
+        return caretAtLineEnd(element: element, descended: nil, descendedIsSecure: nil)
+    }
+
+    /// Same decision from a snapshot the caller already paid for: no second systemwide focused-element
+    /// read, no second descendToEditable BFS.
+    func caretAtLineEnd(in snapshot: FocusSnapshot) -> Bool {
+        guard !snapshot.isSecure else { return true }
+        return caretAtLineEnd(element: snapshot.element,
+                              descended: .some(snapshot.descendedEditable),
+                              descendedIsSecure: snapshot.descendedIsSecure)
+    }
+
+    private func caretAtLineEnd(element: AXUIElement,
+                                descended preDescended: AXUIElement??,
+                                descendedIsSecure preDescendedIsSecure: Bool?) -> Bool {
+        // The editable node under the focused wrapper, skipping a secure one. Resolved at most once per
+        // call — the branches below are mutually exclusive — and not at all when the caller passed one.
+        func editableDescendant() -> AXUIElement? {
+            guard let d = preDescended ?? AXTextProbe.descendToEditable(element) else { return nil }
+            return (preDescendedIsSecure ?? isSecure(d)) ? nil : d
+        }
         // Chromium/WebKit contenteditables (Gmail in a browser) expose a flat kAXValue whose newline
         // counting drifts from kAXSelectedTextRange the moment the body has a line break: the native
         // post-caret read then lands mid-string and falsely reports "mid-line", so the ghost dies on
@@ -219,7 +311,7 @@ final class EditContextTracker {
             // marker range is nil, so the real answer often lives on the descended text node. Take the
             // first DEFINITE (non-.unavailable) answer; only a definite mid-line suppresses.
             let focused = AXTextProbe.webCaretLinePosition(of: element)
-            let descend = AXTextProbe.descendToEditable(element).flatMap { isSecure($0) ? nil : $0 }
+            let descend = editableDescendant()
                 .map { AXTextProbe.webCaretLinePosition(of: $0) } ?? .unavailable
             let probe = focused != .unavailable ? focused : descend
             switch probe {
@@ -246,7 +338,7 @@ final class EditContextTracker {
         case .midLine: return false
         case .unavailable: break
         }
-        if let editable = AXTextProbe.descendToEditable(element), !isSecure(editable) {
+        if let editable = editableDescendant() {
             if let caret = caretLocation(of: editable), let text = elementString(editable) {
                 return Self.isCaretAtLineEnd(text, caret: caret)
             }
@@ -267,8 +359,13 @@ final class EditContextTracker {
         return chars[i] == 10 || chars[i] == 13   // LF / CR
     }
 
-    // Run of text immediately BEFORE the caret only (FR-KC-2). Never read post-caret text —
-    // forward-from-caret keeps inference on the cached prefix-growth path (FINDINGS Spike 2).
+    // Run of text immediately BEFORE the caret (FR-KC-2). This — and only this — is what the model is
+    // PREFILLED with: keeping the prompt a pure forward-growing prefix is what keeps inference on the
+    // cached prefix-growth path (FINDINGS Spike 2), so post-caret text must never be appended here.
+    // Post-caret text IS read now (suffixAfterCaret), because the old prefix-only view let the model
+    // write something that duplicated or contradicted text sitting three lines below the caret and the
+    // single character caretAtLineEnd() peeks at can't see that — but it is a check on the GENERATED
+    // text, kept out of the prompt prefix.
     private func prefixBeforeCaret(_ text: String, caret: Int) -> String {
         let chars = Array(text.utf16)
         let end = min(max(caret, 0), chars.count)
@@ -276,21 +373,66 @@ final class EditContextTracker {
         return String(utf16CodeUnits: Array(chars[0..<end]), count: end)
     }
 
+    // Pure (testable): the run of text immediately AFTER the caret, capped to `maxChars` UTF-16 units.
+    // nil when nothing follows — "no suffix" and "empty suffix" are the same fact, and callers should
+    // not have to special-case "". UTF-16 offsets, matching kAXSelectedTextRange.
+    static func suffixAfterCaret(_ text: String, caret: Int, maxChars: Int) -> String? {
+        guard maxChars > 0 else { return nil }
+        let chars = Array(text.utf16)
+        let start = min(max(caret, 0), chars.count)
+        guard start < chars.count else { return nil }
+        var end = min(chars.count, start + maxChars)
+        // The cap must not slice a surrogate pair in half — an emoji sitting at the cap boundary would
+        // otherwise arrive as U+FFFD. Drop the dangling high surrogate instead. (Caret offsets themselves
+        // come from kAXSelectedTextRange and never land mid-pair.)
+        if end < chars.count, (0xD800...0xDBFF).contains(chars[end - 1]) { end -= 1 }
+        guard end > start else { return nil }
+        let slice = Array(chars[start..<end])
+        return String(utf16CodeUnits: slice, count: slice.count)
+    }
+
+    // Split a field's raw value at the caret, applying the read-chokepoint NBSP fold to BOTH halves so
+    // every consumer of either side sees U+0020 (see normalizingSpaces).
+    private func caretText(_ text: String, caret: Int) -> CaretText {
+        CaretText(prefix: Self.normalizingSpaces(prefixBeforeCaret(text, caret: caret)),
+                  suffix: Self.suffixAfterCaret(text, caret: caret, maxChars: Self.maxSuffixChars)
+                      .map(Self.normalizingSpaces))
+    }
+
     func caretRectOnScreen() -> CGRect? {
         guard let element = currentFocusedElement(), !isSecure(element) else { return nil }
+        return caretRect(element: element, descended: nil, descendedIsSecure: nil, prefix: nil)
+    }
+
+    // Same geometry from a snapshot: reuses the focused element, the descend, and — the real saving —
+    // the prefix the caller already read, so the frame-anchored fallback (c) no longer costs a SECOND
+    // full text resolution on every fire in the Electron/Chromium hosts that always land there.
+    func caretRectOnScreen(in snapshot: FocusSnapshot) -> CGRect? {
+        guard !snapshot.isSecure else { return nil }
+        return caretRect(element: snapshot.element,
+                         descended: .some(snapshot.descendedEditable),
+                         descendedIsSecure: snapshot.descendedIsSecure,
+                         prefix: .some(snapshot.prefix))
+    }
+
+    private func caretRect(element: AXUIElement,
+                           descended preDescended: AXUIElement??,
+                           descendedIsSecure preDescendedIsSecure: Bool?,
+                           prefix prefixResolved: String??) -> CGRect? {
         // (a) Real caret geometry on the focused element (native kAXBoundsForRange or web markers).
         if let rect = caretBounds(of: element) { return rect }
 
         // (b) Web/Electron often keep the editable node a level down; retry caret geometry there.
-        let editable = AXTextProbe.descendToEditable(element)
-        if let editable, !isSecure(editable), let rect = caretBounds(of: editable) { return rect }
+        let editable = preDescended ?? AXTextProbe.descendToEditable(element)
+        let editableIsSecure = editable.map { preDescendedIsSecure ?? isSecure($0) } ?? false
+        if let editable, !editableIsSecure, let rect = caretBounds(of: editable) { return rect }
 
         // (c) Last resort (Chromium/Electron expose no usable caret rect): anchor on the editable
         // element's own frame — the actual text line — and ESTIMATE the caret X by measuring the
         // rendered width of the current line's prefix in the line's font. This lands the ghost right
         // after the typed text instead of at the box's left edge. Prefer the descended editable node
         // (the real text box) over the focused wrapper.
-        let anchorEl: AXUIElement = (editable.flatMap { isSecure($0) ? nil : $0 }) ?? element
+        let anchorEl: AXUIElement = editableIsSecure ? element : (editable ?? element)
         if let frame = elementFrame(anchorEl) {
             // The frame height is the element BOX. For a single-line field that's ≈ the text line, but
             // for a MULTI-LINE field (textarea / web area, hundreds of px tall) it is NOT a line —
@@ -306,7 +448,7 @@ final class EditContextTracker {
             // hair of gap rather than overlap the typed text) — seats the ghost right at the caret.
             let font = NSFont.systemFont(ofSize: max(11, round(lineHeight * 0.70)))
             // Only the last visual line's text contributes to the caret X (text after the last newline).
-            let prefix = currentPrefix() ?? ""
+            let prefix = (prefixResolved ?? currentPrefix()) ?? ""
             let lastLine = prefix.split(separator: "\n", omittingEmptySubsequences: false).last.map(String.init) ?? ""
             // When the last logical line is wider than the box it SOFT-WRAPS. The caret then sits at the end
             // of the *last visual* line — partway along it, holding the overflow text. Measuring the whole
@@ -427,6 +569,13 @@ final class EditContextTracker {
     // there this returns false and callers behave as today (fail-open). Single AX call, no descend.
     func hasMarkedText() -> Bool {
         guard let element = currentFocusedElement() else { return false }
+        return hasMarkedText(of: element)
+    }
+
+    /// Same probe on a snapshot's element — saves the systemwide focused-element read.
+    func hasMarkedText(in snapshot: FocusSnapshot) -> Bool { hasMarkedText(of: snapshot.element) }
+
+    private func hasMarkedText(of element: AXUIElement) -> Bool {
         var ref: CFTypeRef?
         guard AXUIElementCopyAttributeValue(element, "AXMarkedTextRange" as CFString, &ref) == .success,
               let v = ref, CFGetTypeID(v) == AXValueGetTypeID() else { return false }
@@ -526,6 +675,9 @@ final class EditContextTracker {
               let pid = NSWorkspace.shared.frontmostApplication?.processIdentifier,
               rewakedPidThisFocus != pid else { return }
         rewakedPidThisFocus = pid
+        // Waking the tree is exactly the event that can make a focus we recorded as unreadable readable,
+        // so drop the negative cache or the next read would short-circuit on the pre-rewake verdict.
+        invalidateFocusSnapshot()
         electronA11y.apply(pid: pid)
     }
 
@@ -549,27 +701,40 @@ final class EditContextTracker {
         return AXTextProbe.webAreaFullText(of: webArea)
     }
 
+    /// Same text from a snapshot, reusing the web area it already walked up to.
+    func pageContextText(in snapshot: FocusSnapshot) -> String? {
+        guard !snapshot.isSecure, let webArea = snapshot.webArea else { return nil }
+        return AXTextProbe.webAreaFullText(of: webArea)
+    }
+
     // True when the focused field is STRUCTURED input (a search box, or a browser's address/omnibox /
     // find bar) where prose autocomplete is wrong — e.g. "aelo.com" ghosted into the address bar.
     // Gathers the AX facts and defers the decision to the pure ActivationPolicy.isNonProseField.
     // Bypassable by force-activate at the call site. Returns false when nothing is focused.
     func focusedFieldIsNonProse() -> Bool {
-        guard let element = currentFocusedElement() else { return false }
-        let searchSub = subrole(of: element) == (kAXSearchFieldSubrole as String)
-        let editable = AXTextProbe.isEditable(element) || AXTextProbe.descendToEditable(element) != nil
+        guard let snapshot = resolveFocusSnapshot() else { return false }
+        return focusedFieldIsNonProse(in: snapshot)
+    }
+
+    // Snapshot form: every AX fact below — subrole, editability, web area, roles, host, descend — comes
+    // from the single resolution the caller already paid for. This gate on its own used to run TWO
+    // descendToEditable BFS passes (visitCap 64 each) plus its own web-area and document-URL walks, on
+    // every keystroke, and then frontmostDomainHost() walked for the URL a third time.
+    func focusedFieldIsNonProse(in snapshot: FocusSnapshot) -> Bool {
+        let element = snapshot.element
+        let searchSub = snapshot.subrole == (kAXSearchFieldSubrole as String)
+        let editable = snapshot.isEditable || snapshot.descendedEditable != nil
         // A reachable kAXDocument is positive evidence the focus is WEB CONTENT (it's how per-domain
         // rules read the host); the omnibox/find bar carry none. Combine with the parent-walk so a
         // composer counts as "in a web area" even when Chromium hides the AXWebArea from kAXParent.
-        let hasWebArea = AXTextProbe.topWebArea(from: element) != nil
-            || AXTextProbe.documentURL(near: element) != nil
+        let hasWebArea = snapshot.hasWebArea
         // The focused (or descended) editable's role. AXTextArea / AXWebArea = prose content, not chrome.
-        let r = role(of: element)
-            ?? AXTextProbe.descendToEditable(element).flatMap { role(of: $0) }
+        let r = snapshot.role ?? snapshot.descendedRole
         let proseRole = r == (kAXTextAreaRole as String) || r == "AXWebArea"
         // Web-mail header inputs (Gmail/Outlook To/Cc/Bcc/Subject) are AXTextField/AXComboBox inside a
         // page web area — they pass the prose-role check (they aren't a prose role) but the host's own
         // contact autocomplete owns those rows, so a ghost there clashes. Gate by host + role.
-        let host = frontmostDomainHost()
+        let host = snapshot.domainHost
         let structuredMail = ActivationPolicy.isStructuredWebMailField(host: host, role: r)
         let nonProse = ActivationPolicy.isNonProseField(
             isBrowser: ActivationPolicy.isBrowser(bundleId: frontmostBundleId),
@@ -586,8 +751,7 @@ final class EditContextTracker {
         // the focused element and its descended editable (Gmail focuses the wrapper sometimes; Outlook
         // the field itself). Either signal = non-prose.
         guard ActivationPolicy.isBrowser(bundleId: frontmostBundleId) else { return false }
-        let descended = AXTextProbe.descendToEditable(element)
-        let targets: [AXUIElement] = descended.map { [element, $0] } ?? [element]
+        let targets: [AXUIElement] = snapshot.descendedEditable.map { [element, $0] } ?? [element]
         let descriptors = targets.flatMap { AXTextProbe.fieldDescriptors(of: $0) }
         if ActivationPolicy.isWebMailRecipientOrSubject(descriptors: descriptors) {
             Diag.log("nonProse: webMail field descriptors=\(descriptors)")
@@ -680,6 +844,78 @@ final class EditContextTracker {
         return size.height
     }
 
+    // MARK: - Focus snapshot (one AX resolution per fire)
+
+    // Every AX fact the per-keystroke gates ask the tree for, resolved ONCE. Before this a single fire
+    // read the systemwide focused element ~7 times, re-ran the descendToEditable BFS (visitCap 64) in
+    // four separate gates and recomputed the document host 3-4 times; a diag from a real machine caught
+    // the tree being walked ~14 times in 130 ms, every walk returning nil. Resolve one per fire and hand
+    // it to every gate (caretAtLineEnd(in:), focusedFieldIsNonProse(in:), caretRectOnScreen(in:), …).
+    //
+    // Deliberately a VALUE with no lifetime of its own: `prefix`/`suffix` are per-keystroke state, so a
+    // snapshot must never be cached across fires. The only thing that persists between fires is the
+    // negative read cache (see prefixFailure), keyed on the focus generation and dropped by
+    // invalidateFocusSnapshot().
+    struct FocusSnapshot {
+        // The focus generation this was resolved in — the same counter the ghost-font stabilizer and the
+        // capability-flicker gate scope their state by, so a consumer can tell two fires apart.
+        let focusSeq: UInt64
+        let element: AXUIElement
+        let role: String?
+        let subrole: String?
+        let isSecure: Bool
+        // AXTextProbe.isEditable(element): the focused element itself is a readable text node.
+        let isEditable: Bool
+        // The real editable text node under `element` (Slack/Electron/Lexical focus a wrapper whose own
+        // value is empty), with its role and secure flag — resolved here because five gates wanted it.
+        let descendedEditable: AXUIElement?
+        let descendedRole: String?
+        let descendedIsSecure: Bool
+        // Web facts: the top-level AXWebArea (the page, not the compose iframe), the raw kAXDocument URL
+        // and the host it reduces to for the FR-PA-2 per-domain rules.
+        let webArea: AXUIElement?
+        let documentURL: String?
+        let domainHost: String?
+        // Text around the caret, sanitized exactly as currentPrefix()/suffixAfterCaret() return it. Both
+        // nil in a secure field — the read is never even attempted there.
+        let prefix: String?
+        let suffix: String?
+
+        // Positive evidence the focus sits in web CONTENT (a browser's omnibox/find bar carries neither).
+        var hasWebArea: Bool { webArea != nil || documentURL != nil }
+    }
+
+    // Resolve one snapshot. nil only when nothing is focused (or AX is untrusted) — a focused-but-
+    // unreadable field still yields a snapshot with prefix == nil, which is what the gates need to see.
+    func resolveFocusSnapshot() -> FocusSnapshot? {
+        guard let element = currentFocusedElement() else { return nil }
+        let secure = isSecure(element)
+        let descended = AXTextProbe.descendToEditable(element)
+        // Never read text out of a secure field (FR-KC-4) — neither side of the caret.
+        let text = secure ? nil : resolveTextAroundCaret(of: element, descended: .some(descended))
+        let url = AXTextProbe.documentURL(near: element)
+        return FocusSnapshot(
+            focusSeq: focusChangeSequence,
+            element: element,
+            role: role(of: element),
+            subrole: subrole(of: element),
+            isSecure: secure,
+            isEditable: AXTextProbe.isEditable(element),
+            descendedEditable: descended,
+            descendedRole: descended.flatMap { role(of: $0) },
+            descendedIsSecure: descended.map { isSecure($0) } ?? false,
+            webArea: AXTextProbe.topWebArea(from: element),
+            documentURL: url,
+            domainHost: url.flatMap { Self.host(fromDocumentURL: $0) },
+            prefix: text?.prefix,
+            suffix: text?.suffix)
+    }
+
+    // Drop the per-focus state a snapshot resolution can short-circuit on (today: the negative read
+    // cache), so the next resolve walks the tree for real again. Called on focus/value changes and after
+    // an AX-tree rewake — anything that can turn a previously unreadable focus into a readable one.
+    func invalidateFocusSnapshot() { prefixFailure = nil }
+
     // MARK: - Focus + AXObserver
 
     private func refreshFocus() {
@@ -691,6 +927,10 @@ final class EditContextTracker {
         // Re-arm the per-focus-session browser-AX rewake (a stale pid from a prior focus must not
         // block re-priming when the user lands on a fresh Gmail tab in the same browser process).
         rewakedPidThisFocus = nil
+        // This also fires on kAXValueChanged, i.e. the field's content changed — the second reason a
+        // focus recorded as unreadable can become readable (the first being a different element, which
+        // the focus generation already covers). Retry it rather than latch the old verdict.
+        invalidateFocusSnapshot()
 
         var value: CFTypeRef?
         let err = AXUIElementCopyAttributeValue(system, kAXFocusedUIElementAttribute as CFString, &value)
@@ -820,11 +1060,26 @@ final class EditContextTracker {
     // the app doesn't (web/Electron) — the caller then falls back to sizing by the caret line height.
     func caretFont() -> NSFont? {
         guard let element = currentFocusedElement(), !isSecure(element) else { return nil }
+        return caretFont(element: element, descended: nil, descendedIsSecure: nil)
+    }
+
+    /// Same font from a snapshot — no second focused-element read, no second descend BFS.
+    func caretFont(in snapshot: FocusSnapshot) -> NSFont? {
+        guard !snapshot.isSecure else { return nil }
+        return caretFont(element: snapshot.element,
+                         descended: .some(snapshot.descendedEditable),
+                         descendedIsSecure: snapshot.descendedIsSecure)
+    }
+
+    private func caretFont(element: AXUIElement,
+                           descended preDescended: AXUIElement??,
+                           descendedIsSecure preDescendedIsSecure: Bool?) -> NSFont? {
         if let f = fontAtCaret(element) { return f }
         // Web/Chromium (Gmail etc.) don't answer the range-based attributed-string query fontAtCaret
         // uses; read the font via the text-marker attributed string instead so browser ghosts match.
         if let f = AXTextProbe.webFont(of: element) { return f }
-        if let editable = AXTextProbe.descendToEditable(element), !isSecure(editable) {
+        if let editable = preDescended ?? AXTextProbe.descendToEditable(element),
+           !(preDescendedIsSecure ?? isSecure(editable)) {
             return fontAtCaret(editable) ?? AXTextProbe.webFont(of: editable)
         }
         return nil

--- a/Sources/Shadowtype/HFImportSheet.swift
+++ b/Sources/Shadowtype/HFImportSheet.swift
@@ -247,14 +247,15 @@ struct HFImportSheet: View {
             manager.onDownloadProgress = { p in
                 DispatchQueue.main.async { progress = p }
             }
+            // Download into the imports dir directly so we don't need a second copy/move. Hoisted out
+            // of the `do` so the cancel path below can find the resume blob it needs to clean up.
+            let importsDir = (try? FileManager.default.url(
+                for: .applicationSupportDirectory, in: .userDomainMask,
+                appropriateFor: nil, create: true))!
+                .appendingPathComponent("Shadowtype/models/imported", isDirectory: true)
+            let target = importsDir.appendingPathComponent(filename)
             do {
-                // Download into the imports dir directly so we don't need a second copy/move.
-                let importsDir = (try? FileManager.default.url(
-                    for: .applicationSupportDirectory, in: .userDomainMask,
-                    appropriateFor: nil, create: true))!
-                    .appendingPathComponent("Shadowtype/models/imported", isDirectory: true)
                 try FileManager.default.createDirectory(at: importsDir, withIntermediateDirectories: true)
-                let target = importsDir.appendingPathComponent(filename)
                 let final = try await manager.downloadAuthenticated(
                     from: downloadURL, to: target, token: usedToken)
 
@@ -285,7 +286,15 @@ struct HFImportSheet: View {
                     dismiss()
                 }
             } catch is CancellationError {
-                // User hit Cancel — the sheet is already dismissing; nothing to report.
+                // User hit Cancel — the sheet is already dismissing; nothing to report. But cancelling
+                // now produces resume data by design, and URLSession keeps its multi-GB temp file alive
+                // for as long as that blob exists. The sheet treats Cancel as full abandonment (the
+                // import is never registered), so keeping the blob would silently cost the user
+                // gigabytes with nothing in the UI to explain or reclaim it. Dropping it unpins the
+                // temp file for the system's tmp purge.
+                let resumeURL = ModelManager.resumeDataURL(for: target, source: downloadURL)
+                try? FileManager.default.removeItem(at: resumeURL)
+                try? FileManager.default.removeItem(at: ModelManager.linkedMetadataURL(for: resumeURL))
                 return
             } catch {
                 await MainActor.run {
@@ -307,6 +316,9 @@ struct HFImportSheet: View {
             return "Could not contact HuggingFace: \(msg)"
         case .noGGUFFiles:
             return "No .gguf files found in this repo."
+        case .sharded(let msg):
+            // No "could not contact" prefix: the repo answered, we are declining what it ships.
+            return "This repo can't be imported — \(msg)"
         }
     }
 

--- a/Sources/Shadowtype/HFResolver.swift
+++ b/Sources/Shadowtype/HFResolver.swift
@@ -25,6 +25,10 @@ enum HFResolver {
         case http(Int)
         case malformed(String)
         case noGGUFFiles
+        /// Every GGUF in the repo is one part of a split model. Its own case rather than `.malformed`
+        /// because the sheet prefixes that one with "Could not contact HuggingFace" — which is false
+        /// here: the repo resolved fine, we just refuse what it ships. Payload is the explanation.
+        case sharded(String)
     }
 
     struct Sibling: Equatable {
@@ -56,8 +60,16 @@ enum HFResolver {
             guard filename.hasSuffix(".gguf") else {
                 return .invalid(reason: "direct URL must point at a .gguf file (got \(filename))")
             }
+            let base = (filename as NSString).lastPathComponent
+            // A shard carries the GGUF magic, so downloading one "succeeds" and then dies at load with
+            // the generic "may be corrupt or unsupported". Say why instead.
+            if let shard = shardInfo(base) {
+                return .invalid(reason: "\(base) is part \(shard.index) of \(shard.total) of a split "
+                                + "model. A single shard cannot be loaded on its own — pick a file that "
+                                + "ships the whole model as one .gguf.")
+            }
             return .directFile(owner: owner, repo: repo, revision: revision,
-                               filename: (filename as NSString).lastPathComponent,
+                               filename: base,
                                downloadURL: url)
         }
 
@@ -67,7 +79,8 @@ enum HFResolver {
     }
 
     // GET https://huggingface.co/api/models/{owner}/{repo} → parse siblings array, filter to
-    // .gguf files, build canonical download URLs. The HF API returns:
+    // importable .gguf files (single-file only — see `shardInfo`), build canonical download URLs.
+    // The HF API returns:
     //   { "siblings": [ {"rfilename": "...", "size": <bytes-optional>}, ... ] }
     static func listGGUFs(owner: String, repo: String, token: String? = nil,
                           session: URLSession = .shared,
@@ -100,8 +113,15 @@ enum HFResolver {
                 guard let dl = Self.siblingDownloadURL(owner: owner, repo: repo, name: name) else { return nil }
                 return Sibling(filename: name, sizeBytes: size, downloadURL: dl)
             }
-            if ggufs.isEmpty { completion(.failure(.noGGUFFiles)); return }
-            completion(.success(ggufs))
+            // Split repos (essentially every 70B-class repo, i.e. exactly what BYOM exists for) must
+            // never reach the picker: importing one shard registers a model that cannot load.
+            let split = Self.partitionShards(ggufs)
+            if split.whole.isEmpty {
+                if split.shards.isEmpty { completion(.failure(.noGGUFFiles)) }
+                else { completion(.failure(.sharded(Self.shardRejectionMessage(split.shards)))) }
+                return
+            }
+            completion(.success(split.whole))
         }
         task.resume()
     }
@@ -128,9 +148,64 @@ enum HFResolver {
     }
 
     // Default pick for the import picker: a Q4_K_M quant when the repo has one (the recommended
-    // quality/size balance, matching the curated catalog), else the first file. Pure + testable.
+    // quality/size balance, matching the curated catalog), preferring an imatrix build of that same
+    // quant — same file size and speed, measurably lower perplexity on rare tokens and non-English
+    // text — else the first file. Shards are never pre-selected: they cannot load alone. Pure + testable.
     static func preferredImportFile(in list: [Sibling]) -> Sibling? {
-        list.first { $0.filename.lowercased().contains("q4_k_m") } ?? list.first
+        let usable = list.filter { shardInfo($0.filename) == nil }
+        let q4 = usable.filter { $0.filename.lowercased().contains("q4_k_m") }
+        return q4.first(where: { isIMatrixBuild($0.filename) }) ?? q4.first ?? usable.first
+    }
+
+    // MARK: - Sharded (split) GGUFs
+
+    // A split model is published as `<name>-00001-of-00003.gguf`: llama.cpp needs EVERY shard present
+    // in one directory to load it, but the import flow downloads exactly one file. Since each shard
+    // still starts with the GGUF magic, accepting one passes validation, registers the model, and then
+    // fails at load with the generic "may be corrupt or unsupported" — so detect the pattern and say
+    // what is actually wrong. `-00001-of-00001` is a complete model despite the suffix, so it is NOT a
+    // shard. Pure + testable.
+    static func shardInfo(_ filename: String) -> (index: Int, total: Int)? {
+        let base = (filename as NSString).lastPathComponent.lowercased()
+        guard base.hasSuffix(".gguf") else { return nil }
+        let parts = String(base.dropLast(".gguf".count)).split(separator: "-",
+                                                               omittingEmptySubsequences: false)
+        guard parts.count >= 3, parts[parts.count - 2] == "of" else { return nil }
+        let idxPart = parts[parts.count - 3], totalPart = parts[parts.count - 1]
+        func isFiveDigits(_ s: Substring) -> Bool {
+            s.count == 5 && s.allSatisfy { c in c.isASCII && c.isNumber }
+        }
+        guard isFiveDigits(idxPart), isFiveDigits(totalPart),
+              let index = Int(idxPart), let total = Int(totalPart),
+              total >= 2, index >= 1, index <= total else { return nil }
+        return (index, total)
+    }
+
+    // Separate importable single-file GGUFs from the shards we refuse. Pure so the sharded-repo case
+    // is testable without a network call.
+    static func partitionShards(_ list: [Sibling]) -> (whole: [Sibling], shards: [Sibling]) {
+        var whole: [Sibling] = [], shards: [Sibling] = []
+        for s in list {
+            if shardInfo(s.filename) == nil { whole.append(s) } else { shards.append(s) }
+        }
+        return (whole, shards)
+    }
+
+    // User-facing explanation for a repo whose GGUFs are ALL shards. Names a concrete file so the user
+    // can see the `-00001-of-000NN` pattern we rejected rather than guessing.
+    static func shardRejectionMessage(_ shards: [Sibling]) -> String {
+        let example = shards.first?.filename ?? "…-00001-of-00002.gguf"
+        return "every GGUF in this repo is one part of a split model (e.g. \(example)). Shadowtype "
+            + "imports a single file, and one shard cannot be loaded on its own — pick a repo that "
+            + "ships the model as a single .gguf."
+    }
+
+    // mradermacher publishes imatrix quants as `…i1-Q4_K_M.gguf` (from its `-i1-GGUF` repos); other
+    // uploaders mark them `imat`/`imatrix`. Matched as a whole token so a model name that merely
+    // contains those letters can't be mistaken for one. Pure + testable.
+    static func isIMatrixBuild(_ filename: String) -> Bool {
+        let tokens = filename.lowercased().split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+        return tokens.contains { $0 == "i1" || $0 == "imat" || $0 == "imatrix" }
     }
 
     // Best-effort short label for a sibling row in the picker UI.

--- a/Sources/Shadowtype/InferenceEngine.swift
+++ b/Sources/Shadowtype/InferenceEngine.swift
@@ -31,6 +31,11 @@ enum InferenceError: Error, LocalizedError {
     // dropped tokens would be fim_pre / fim_suf — framing the model was trained on. Routes catch
     // this and return HTTP 400 with a clear message instead of letting the model emit garbage.
     case fimContextOverflow(tokens: Int, cap: Int)
+    // The requested `max_tokens` reserves so much of the context for generation that the over-cap
+    // prompt would have to be front-trimmed to a stub. Answering from a stub looks like a model
+    // failure, so the request is refused; routes should surface it as HTTP 400 (fixable by the
+    // caller: shorten the prompt or lower max_tokens).
+    case promptWindowExhausted(tokens: Int, cap: Int, maxTokens: Int)
 
     var errorDescription: String? {
         switch self {
@@ -40,6 +45,8 @@ enum InferenceError: Error, LocalizedError {
         case .tokenizeFailed:             return "Tokenization failed."
         case .decodeFailed(let code):     return "llama_decode failed (code \(code))."
         case .fimContextOverflow(let t, let cap): return "Context overflow: \(t) tokens exceed the \(cap)-token cap."
+        case .promptWindowExhausted(let t, let cap, let mt):
+            return "Prompt is \(t) tokens but only \(cap) fit alongside max_tokens=\(mt) — shorten the prompt or lower max_tokens."
         }
     }
 }
@@ -336,7 +343,8 @@ final class InferenceEngine: InferenceEngineProtocol {
 
     // `onSample`, when provided, is invoked once per sampled CONTENT token (a token whose decoded
     // piece carries a visible, non-whitespace character), on the engine's inference thread, BEFORE that
-    // token's word(s) are flushed via `onToken`. It reports the token's post-sampler probability and
+    // token's word(s) are flushed via `onToken`. It reports the step's RAW top-1 probability (the peak of
+    // the model's own distribution, before the sampler chain distorts it — see sampleWithProb) and
     // whether it is the FIRST content token of this generation. The coordinator uses this for confidence
     // gating (suppress low-probability/flailing completions) — decoupled from word-flush boundaries so a
     // multi-token word doesn't smear the per-token signal.
@@ -383,13 +391,14 @@ final class InferenceEngine: InferenceEngineProtocol {
         guard !tokens.isEmpty else { return }
         let nCtx = Int(llama_n_ctx(ctx))
         // Cap at the live context minus head-room, and further at the user's configured window. The
-        // head-room is NOT cosmetic: the ghost decodes its generated tokens into THIS same seq's KV
-        // after prefill, and with kv_unified the API/MCP seq shares the same n_ctx pool — so a prompt
-        // filling to nCtx-4 leaves no room to generate (or for a co-resident seq) and llama_decode
-        // returns 1 mid-stream. Reserve a generation+co-seq margin so a long prompt front-trims
-        // gracefully instead of silently failing. (genReserve >> max ghost output of ~tens of tokens.)
-        let genReserve = 256
-        let cap = max(8, min(nCtx - genReserve, maxContextTokens))
+        // head-room is NOT cosmetic: both decode loops append every generated token to THIS same seq's
+        // KV after prefill, and with kv_unified the API/MCP seq shares the same n_ctx pool — so a
+        // prompt filling to nCtx-4 leaves no room to generate (or for a co-resident seq) and
+        // llama_decode returns 1 mid-stream. The reserve tracks the tokens this call will ACTUALLY
+        // generate (see generationReserve): it used to be a flat 256 while /v1 admits max_tokens up to
+        // 2048, so a prompt at the cap plus 2048 generated tokens overran the 4096 pool and the stream
+        // died mid-response with a 500.
+        let cap = Self.promptCap(nCtx: nCtx, maxTokens: maxTokens, maxContextTokens: maxContextTokens)
         if tokens.count > cap {
             // M5 review #2: refuse to truncate when the prompt is a FIM token stream — front-trim
             // drops `fim_pre` first (and on tighter caps `fim_suf`), leaving the model with framing
@@ -399,6 +408,14 @@ final class InferenceEngine: InferenceEngineProtocol {
             // there (FINDINGS §cold; the deadline-drop hides the cold-prefill cost).
             if params.fim != nil {
                 throw InferenceError.fimContextOverflow(tokens: tokens.count, cap: cap)
+            }
+            // A large `maxTokens` can squeeze the prompt window below anything usable (max_tokens 4000
+            // against a 4096 context leaves ~32 tokens). Front-trimming there would answer from a stub
+            // of the prompt and look like a model failure, so fail the request instead — the caller can
+            // shorten the prompt or lower max_tokens. Only the RESERVE may trigger this: a user who
+            // deliberately set a small "Context window size" still gets the trim they asked for.
+            if nCtx - Self.generationReserve(maxTokens: maxTokens) < Self.minPromptWindow {
+                throw InferenceError.promptWindowExhausted(tokens: tokens.count, cap: cap, maxTokens: maxTokens)
             }
             // The raw path front-trims (most-recent-context wins), but NOT with a plain suffix: that
             // dropped the BOS that tokenize(addSpecial: true) put at index 0, and Gemma-3 — the
@@ -511,6 +528,23 @@ final class InferenceEngine: InferenceEngineProtocol {
             llama_sampler_chain_add(smpl, llama_sampler_init_dist(params.seed))
         }
 
+        // Seed the repetition-penalty window with the tail of the PROMPT. llama_sampler_accept was
+        // only ever called for tokens THIS call generated, so with repeatPenaltyLastN 64 and maxTokens
+        // 16-24 the window started empty and never held a single prompt token: nothing at sampling
+        // time discouraged the ghost from echoing the words the user had just typed (the coordinator
+        // compensates after the fact by HIDING the whole suggestion — isPrefixDuplicate — where one
+        // logit adjustment would have produced a good one), while the penalty still punished
+        // legitimate short-range repetition inside a 12-word completion. Chronological order matters:
+        // llama.cpp's penalties sampler keeps a ring buffer of the last `penalty_last_n` accepted
+        // tokens, so the most recent prompt token must be accepted LAST. Only when a penalties sampler
+        // is actually in the chain — the greedy branch adds none, and penalty_last_n == 0 is a
+        // documented no-op in its apply.
+        if !(useGreedyEnv || params.greedy) {
+            for t in Self.penaltyPrimeTokens(prompt: tokens, lastN: params.repeatPenaltyLastN) {
+                llama_sampler_accept(smpl, t)
+            }
+        }
+
         // --- Decode loop ------------------------------------------------------------------------
         // Reusable candidate buffer for manual sample-with-probability (avoids a per-token vocab-sized
         // alloc; the decode budget is tiny — maxTokens). `cur.data` is modified in place by the chain.
@@ -564,18 +598,26 @@ final class InferenceEngine: InferenceEngineProtocol {
         var emitted = 0
         var sawNonSpace = false   // suppress leading-whitespace-only output and never stop on a leading boundary char
         var flushedAny = false    // did this run hand the consumer any whole word yet?
-        var wordCount = 0         // completed words flushed so far (a leading-space piece opens a new word)
+        var wordCount = 0         // words so far: a leading-space piece opens one, and in a space-less
+                                  // script (CJK/kana/Thai) each character IS one
         var pending = ""          // un-flushed trailing fragment (the possibly-incomplete current word)
 
         // Flush every settled word in `pending` (text up to and including each interior whitespace),
         // one whitespace-delimited chunk per onToken call so streaming stays incremental (the
         // consumer sees the ghost grow word-by-word, as before). Holds back only the trailing
         // (possibly-incomplete) word, which a hard stop will drop. Returns false on consumer cancel.
+        //
+        // A space-less-script character (CJK / kana / Thai …) closes a word too: those languages emit
+        // no interior whitespace, so a whitespace-only rule streamed NOTHING for them — the entire
+        // completion escaped through the `!flushedAny` fallback at the very end of the run, with no
+        // early first-token render to beat the deadline drop.
         func flushCompleteWords() -> Bool {
             guard sawNonSpace else { return true }   // don't emit leading-whitespace-only output
-            while let firstSpace = pending.firstIndex(where: { $0.isWhitespace }) {
-                let head = String(pending[...firstSpace])
-                pending = String(pending[pending.index(after: firstSpace)...])
+            while let boundary = pending.firstIndex(where: {
+                $0.isWhitespace || SentenceBoundary.isSpacelessScript($0)
+            }) {
+                let head = String(pending[...boundary])
+                pending = String(pending[pending.index(after: boundary)...])
                 if !head.isEmpty {
                     flushedAny = true
                     if !onToken(head) { return false }
@@ -598,7 +640,6 @@ final class InferenceEngine: InferenceEngineProtocol {
                 return
             }
             llama_sampler_accept(smpl, tok)
-            let tokProb = (useGreedyEnv ? 1.0 : confProb)
             let hadContentBefore = sawNonSpace
 
             var piece = tokenToPiece(tok)
@@ -616,6 +657,11 @@ final class InferenceEngine: InferenceEngineProtocol {
             if !piece.isEmpty {
                 // A new word starts whenever a piece opens with whitespace after we've seen content.
                 if sawNonSpace, let first = piece.first, first.isWhitespace { wordCount += 1 }
+                // …and every space-less-script character IS a word: those scripts never produce a
+                // leading-whitespace piece, so the rule above left wordCount at 0 forever and both the
+                // maxWords cap and stopAtSentenceAfterWords were unreachable for CJK/Japanese/Thai —
+                // the generation ran to maxTokens every time.
+                wordCount += piece.reduce(0) { $0 + (SentenceBoundary.isSpacelessScript($1) ? 1 : 0) }
 
                 // Newline handling. A line break AFTER real content is a clean stop (end the ghost on
                 // the line). But a LEADING newline — before any content has been emitted — is the
@@ -674,7 +720,7 @@ final class InferenceEngine: InferenceEngineProtocol {
                 // confidence gate can suppress before the first render. `isFirstContent` marks the token
                 // that first produced visible output.
                 if piece.contains(where: { !$0.isWhitespace }) {
-                    onSample?(tokProb, !hadContentBefore)
+                    onSample?(confProb, !hadContentBefore)
                 }
                 if !flushCompleteWords() { return }   // cooperative cancel via closure (FR-CE-4)
             }
@@ -743,7 +789,7 @@ final class InferenceEngine: InferenceEngineProtocol {
 
             let piece = tokenToPiece(tok)
             if !piece.isEmpty {
-                onSample?(useGreedyEnv ? 1.0 : confProb, !firstContentReported)
+                onSample?(confProb, !firstContentReported)
                 firstContentReported = true
                 let (chunk, stopped) = stopFilter.push(piece)
                 if !chunk.isEmpty, !onToken(chunk) { return }
@@ -824,6 +870,35 @@ final class InferenceEngine: InferenceEngineProtocol {
         var i = 0
         while i < cached.count, i < maxKeep, cached[i] == new[i] { i += 1 }
         return i
+    }
+
+    // Prompt tokens to replay through llama_sampler_accept so the repetition-penalty ring buffer
+    // reflects what the user actually wrote (see the call site). The LAST `lastN` tokens, in
+    // chronological order — the ring buffer evicts from the front, so a longer replay would just push
+    // the recent tokens back out. Empty when no penalty window is configured.
+    // llama_token is a typealias for Int32; spelled Int32 so this stays callable from the test target
+    // without importing CLlama.
+    static func penaltyPrimeTokens(prompt: [Int32], lastN: Int32) -> ArraySlice<Int32> {
+        guard lastN > 0 else { return [][...] }
+        return prompt.suffix(Int(lastN))
+    }
+
+    // Smallest prompt window worth honouring: below this the front-trim leaves a stub rather than
+    // context, so generate() refuses the request instead (see promptWindowExhausted).
+    static let minPromptWindow = 512
+
+    // KV cells held back from the prompt for the tokens this call will generate. Both decode loops
+    // grow the same seq's KV token by token, so the reserve has to cover `maxTokens` — a flat 256
+    // (the pre-fix value) plus a /v1 request's max_tokens of 2048 overran the 4096 pool and killed the
+    // stream mid-response. The 256 floor is the co-resident-seq margin kv_unified needs and keeps the
+    // ghost path (maxTokens ~16-24) byte-identical to the old behaviour; +64 is slack for the
+    // single-token decode batches themselves.
+    static func generationReserve(maxTokens: Int) -> Int { max(256, maxTokens + 64) }
+
+    // Prompt-token budget for one generate(): the live context minus the generation reserve, then the
+    // user's configured "Context window size". Floored at 8 so the arithmetic can't go negative.
+    static func promptCap(nCtx: Int, maxTokens: Int, maxContextTokens: Int) -> Int {
+        max(8, min(nCtx - generationReserve(maxTokens: maxTokens), maxContextTokens))
     }
 
     // Granularity of the front-trim window (FIX 4). See trimToWindow.
@@ -930,16 +1005,27 @@ final class InferenceEngine: InferenceEngineProtocol {
     // MARK: - Helpers
 
     // Sample one token from the last-evaluated logits and return it together with the model's
-    // CONFIDENCE for that step — the PEAK of the post-sampler distribution (the top token's prob),
-    // NOT the sampled token's prob. Replicates the llama_sampler_sample() shorthand (apply chain ->
-    // read selected) but WITHOUT the internal accept (the caller accepts once).
+    // CONFIDENCE for that step — the PEAK of the model's RAW (pre-sampler-chain) distribution, NOT
+    // the sampled token's prob. Replicates the llama_sampler_sample() shorthand (apply chain -> read
+    // selected) but WITHOUT the internal accept (the caller accepts once).
     //
     // Why peak-prob and not the sampled token's prob: the chain ends in `dist` (stochastic), so the
     // SELECTED token is frequently NOT the top token under temperature. The confidence gate asks
     // "is the model flailing?" — a property of how peaked the distribution is, independent of the
     // random draw. Gating on the sampled token's prob hid confident completions whenever the draw
     // landed on a lower-probability token (the "low first-token confidence -> hide everything" bug).
-    // Falls back to the plain sampler (conf 0) if logits are unavailable or nothing was selected.
+    //
+    // Why RAW and not the post-chain peak: the peak used to be read off `data[i].p` AFTER
+    // llama_sampler_apply had run the whole chain — after top_k(40) truncated, after top_p(0.9)
+    // truncated AND RENORMALIZED, and after temp 0.4 divided every logit by 0.4 (a 2.5x sharpening).
+    // A step whose true top-1 probability is 0.10, spread over ~40 near-uniform survivors, reported
+    // ~0.5 that way — five times the 0.10 first-token threshold — so both confidence gates only fired
+    // on an almost perfectly flat distribution, i.e. essentially never. Reading the raw logits also
+    // makes the number meaningful under greedy sampling: llama_sampler_init_greedy is an argmax with
+    // NO softmax, so the post-chain scan returned p == 0 for every token and the gate would have
+    // suppressed everything the moment `params.greedy` was set (the API temperature == 0 path, and the
+    // one-line experiment any maintainer would try on the ghost).
+    // Falls back to the plain sampler if logits are unavailable (conf 0 = unknown).
     private func sampleWithProb(ctx: OpaquePointer,
                                 smpl: UnsafeMutablePointer<llama_sampler>,
                                 nVocab: Int,
@@ -952,26 +1038,39 @@ final class InferenceEngine: InferenceEngineProtocol {
         // prefix-compatible with the remaining stem — done in the candidate fill the loop already runs,
         // so it's near-free, and only while a stem is being satisfied (the first 1–3 tokens).
         let constrained = !requiredRemaining.isEmpty
+        var maxLogit = -Float.infinity
         for i in 0..<nVocab {
             var lg = logits[i]
             if constrained,
                !RequiredPrefix.isAdmissible(tokenBytes: tokenBytesSlice(llama_token(i)), remaining: requiredRemaining) {
                 lg = -.infinity
             }
+            if lg > maxLogit { maxLogit = lg }
             cand[i] = llama_token_data(id: llama_token(i), logit: lg, p: 0)
         }
+        // Raw softmax peak = exp(maxLogit - logSumExp) = 1 / Σexp(logit - maxLogit). Subtracting the
+        // max first is what keeps the exponentials in range on a 262k-token vocab. Masked (-inf)
+        // entries drop out of both max and sum, so a healed step reports the peak among the tokens the
+        // required-prefix constraint actually left admissible.
+        var sumExp = 0.0
+        if maxLogit > -.infinity {
+            // Terms more than 20 nats below the peak contribute < 2.1e-9 each (< 6e-4 total across the
+            // whole vocab), and skipping them turns ~262k expf() calls per SAMPLED TOKEN — milliseconds
+            // out of a 400 ms end-to-end budget — into a compare sweep plus a few thousand exps.
+            let cutoff = maxLogit - 20
+            for i in 0..<nVocab where cand[i].logit > cutoff {
+                sumExp += Double(exp(cand[i].logit - maxLogit))
+            }
+        }
+        let rawPeak: Float = sumExp > 0 ? Float(1.0 / sumExp) : 0
         return cand.withUnsafeMutableBufferPointer { buf -> (llama_token, Float) in
             var cur = llama_token_data_array(
                 data: buf.baseAddress, size: nVocab, selected: -1, sorted: false)
             llama_sampler_apply(smpl, &cur)
             guard cur.selected >= 0, let data = cur.data else {
-                return (llama_sampler_sample(smpl, ctx, -1), 0)
+                return (llama_sampler_sample(smpl, ctx, -1), rawPeak)
             }
-            // Peak of the surviving (post-top_k/top_p/temp, softmaxed by `dist`) candidates. cur.size
-            // is bounded by top_k (40), so this scan is cheap on the hot path.
-            var peakProb: Float = 0
-            for i in 0..<cur.size { let p = data[i].p; if p > peakProb { peakProb = p } }
-            return (data[Int(cur.selected)].id, peakProb)
+            return (data[Int(cur.selected)].id, rawPeak)
         }
     }
 

--- a/Sources/Shadowtype/InferenceEngine.swift
+++ b/Sources/Shadowtype/InferenceEngine.swift
@@ -198,6 +198,17 @@ final class InferenceEngine: InferenceEngineProtocol {
     // latency becomes one 256-token chunk, still well under a frame.
     private let prefillChunk: Int = 256
 
+    // NOT overriding n_threads / n_threads_batch, deliberately. The tempting argument — "a background
+    // menu-bar app should not run a core-count-wide thread pool against the user's foreground work" —
+    // rests on a false premise: llama does NOT size these from the core count. `llama_context_default_params`
+    // sets both to GGML_DEFAULT_N_THREADS, which is a hard-coded 4 (ggml.h). So a "narrower than default"
+    // override changes nothing on Pro/Max-class CPUs (4 P-cores' worth either way) and only HALVES the
+    // base M-series Macs to 2 — the machines with the least headroom, in the direction that could cost
+    // latency. Every layer is Metal-offloaded (n_gpu_layers = 999), so the CPU side is sampling plus a
+    // few non-offloaded ops and probably does not care either way; "probably" is the point. This is a
+    // measurable question and InferenceEnginePerfTests exists for it — set these once there is a
+    // before/after number, not before.
+
     // Set to true via env SHADOWTYPE_GREEDY to force deterministic greedy sampling across both
     // ghost and API paths regardless of `SamplingParams.greedy`.
     private let useGreedyEnv = ProcessInfo.processInfo.environment["SHADOWTYPE_GREEDY"] != nil
@@ -343,7 +354,7 @@ final class InferenceEngine: InferenceEngineProtocol {
 
         // FR-CE-8: confirm the Metal backend initialised. llama.cpp logs "ggml_metal_init: ..."
         // to stderr during model load; this line ties that to our context so it's greppable.
-        NSLog("Shadowtype: InferenceEngine loaded model (Metal, n_gpu_layers=999, n_ctx=\(llama_n_ctx(c)), n_seq_max=\(maxSeqCount), arch=\(modelArchitecture ?? "?"), chatTemplate=\(modelChatTemplate != nil ? "yes" : "no"), supportsChat=\(modelSupportsChat), fim=\(modelFIMTokens != nil ? "yes" : "no"), maskedControl=\(maskedSpecialBias.count))")
+        NSLog("Shadowtype: InferenceEngine loaded model (Metal, n_gpu_layers=999, n_ctx=\(llama_n_ctx(c)), n_threads=\(llama_n_threads(c)), n_seq_max=\(maxSeqCount), arch=\(modelArchitecture ?? "?"), chatTemplate=\(modelChatTemplate != nil ? "yes" : "no"), supportsChat=\(modelSupportsChat), fim=\(modelFIMTokens != nil ? "yes" : "no"), maskedControl=\(maskedSpecialBias.count))")
 
         self.cachedTokensBySeq.removeAll(keepingCapacity: false)
         self.nPastBySeq.removeAll(keepingCapacity: false)

--- a/Sources/Shadowtype/InferenceEngine.swift
+++ b/Sources/Shadowtype/InferenceEngine.swift
@@ -97,9 +97,18 @@ final class InferenceEngine: InferenceEngineProtocol {
         isSpecial && !isEOG && !isFIM
     }
 
-    // Tier 2a: lazily-built flat table of every token's rendered bytes, for the required-prefix
-    // (mid-word healing) sampler mask. off[i]..<off[i+1] are token i's bytes. ~1–2 MB; built once on
-    // the first healed completion (a ~262k-token sweep), so normal generation never pays for it.
+    // Tier 2a: flat table of every token's rendered bytes, for the required-prefix (mid-word healing)
+    // sampler mask. off[i]..<off[i+1] are token i's bytes. ~1–2 MB, a ~262k-token sweep with two
+    // allocations per token. Built once at the END of load(), NOT lazily on the first healed
+    // completion: lazily it landed between prefill and the first sampled token — squarely inside the
+    // latency budget of the very completion that needed it — and mid-word healing is default-ON, so
+    // that is the common case, not a rare one.
+    //
+    // unload() MUST clear all three. CompletionCoordinator.reloadModel is unload+load on the SAME
+    // engine instance, so after a Settings model swap a surviving table returns the PREVIOUS model's
+    // bytes: the ghost renders old-vocab byte strings, and when the new vocab is larger the ids past
+    // the stale table return an empty slice, which RequiredPrefix.isAdmissible rejects — -inf on every
+    // candidate, i.e. empty ghosts until relaunch, with nothing logged.
     private var tokenByteBuf: [UInt8] = []
     private var tokenByteOff: [Int32] = []
     private var tokenByteTableReady = false
@@ -127,6 +136,14 @@ final class InferenceEngine: InferenceEngineProtocol {
         guard n > 0 else { return [] }
         return (0..<Int(n)).map { UInt8(bitPattern: buf[$0]) }
     }
+
+    // Candidate buffer for sampleWithProb, hoisted out of generate(): on a 262k-token vocab this is a
+    // ~3.1 MB allocation that the old per-call `var cand` paid on EVERY generate — i.e. on every
+    // keystroke that fires a ghost. Resized only when the vocab size changes (a model swap). Safe to
+    // share because the inferenceQueue is serial: exactly one generate() is ever in flight, and it is
+    // the only reader/writer. Passed `inout` into the decode loops, which never touch `self.cand`
+    // themselves, so the inout access never overlaps a second access to this property.
+    private var cand: [llama_token_data] = []
 
     // KV-cache reuse state (FR-CE-5), now keyed by llama.cpp sequence ID. `cachedTokensBySeq[seq]`
     // is the exact token stream currently committed to the KV cache for that seq, and
@@ -156,8 +173,15 @@ final class InferenceEngine: InferenceEngineProtocol {
     // Tunables.
     private let contextSize: UInt32 = 4096
     private let batchSize: UInt32 = 512
-    private let maxSeqCount: Int32 = 4   // ghost (0) + API (1) + headroom; cparams.n_seq_max
-    private let prefillChunk: Int = 48   // tokens per prefill batch; cancel is checked between chunks (FR-CE-4)
+    private let maxSeqCount: Int32 = 4   // ghost (0) + API (1) + selection rewrite (2) + headroom; cparams.n_seq_max
+    // Tokens per llama_decode during prefill, and the only cancel-latency knob we have: cancel is
+    // polled BETWEEN chunks (FR-CE-4), and llama_set_abort_callback is a documented no-op for
+    // GPU-offloaded work — which is all of it here (n_gpu_layers = 999). The old value of 48 bought
+    // finer cancel granularity at the cost of starving the GPU: it, not cparams.n_batch (512), governs
+    // the real batch width, so a 1024-token cold prefill was ~22 Metal graph builds + submits + waits
+    // at a tenth of the configured batch. 256 is 4 dispatches for that same prefill; worst-case cancel
+    // latency becomes one 256-token chunk, still well under a frame.
+    private let prefillChunk: Int = 256
 
     // Set to true via env SHADOWTYPE_GREEDY to force deterministic greedy sampling across both
     // ghost and API paths regardless of `SamplingParams.greedy`.
@@ -218,9 +242,10 @@ final class InferenceEngine: InferenceEngineProtocol {
         var cparams = llama_context_default_params()
         cparams.n_ctx = contextSize
         cparams.n_batch = batchSize
-        // Multi-seq context: ghost on seq 0, API/MCP on seq 1. Headroom in case future surfaces
-        // (a second API client, a parallel embedding job) want their own KV slot too. The header
-        // recommends swa_full=true with n_seq_max > 1 to avoid SWA performance cliffs.
+        // Multi-seq context: ghost on seq 0, API/MCP on seq 1, selection rewrite on seq 2 (its few-shot
+        // prompt diverges at token 0, so sharing seq 0 evicted the ghost's cached prefix). One slot of
+        // headroom left in case a future surface wants its own KV slot too. The header recommends
+        // swa_full=true with n_seq_max > 1 to avoid SWA performance cliffs.
         cparams.n_seq_max = UInt32(maxSeqCount)
         cparams.swa_full = true
         // kv_unified=true shares ONE n_ctx-sized buffer across all sequences. With the default (false)
@@ -228,7 +253,8 @@ final class InferenceEngine: InferenceEngineProtocol {
         // tokens at 4096/4): a long page-context + prefix prompt (e.g. a multi-paragraph Reddit/forum
         // post) overflows the partition and `llama_decode` returns 1 (no KV slot) — the ghost silently
         // dies on exactly the long-prose case it's most wanted. Unify so the ghost can use the full
-        // window; ghost (0) and the occasional API/MCP seq (1) rarely both run near-full at once.
+        // window; ghost (0) and the occasional API/MCP (1) or selection-rewrite (2) seq rarely both run
+        // near-full at once.
         cparams.kv_unified = true
         // Flash Attention speeds the prefill of long prefixes (the page-context / thread-aware case) on
         // Metal. AUTO enables it whenever the model+backend support it and is a safe no-op otherwise —
@@ -283,6 +309,11 @@ final class InferenceEngine: InferenceEngineProtocol {
                 bias.append(llama_logit_bias(token: id, bias: -Float.infinity))
             }
             self.maskedSpecialBias = bias
+
+            // Tier 2a: build the token-byte table here, on the load thread, instead of on the first
+            // healed completion — see tokenByteBuf. Same one-pass cost, paid where nobody is waiting
+            // on a ghost. unload() cleared it, so this always rebuilds for the newly loaded vocab.
+            ensureTokenByteTable(nVocab: Int(n))
         }
 
         // FR-CE-8: confirm the Metal backend initialised. llama.cpp logs "ggml_metal_init: ..."
@@ -310,7 +341,8 @@ final class InferenceEngine: InferenceEngineProtocol {
     // gating (suppress low-probability/flailing completions) — decoupled from word-flush boundaries so a
     // multi-token word doesn't smear the per-token signal.
     //
-    // `seqID` selects which llama.cpp sequence this call belongs to (ghost = 0, API = 1). `params`
+    // `seqID` selects which llama.cpp sequence this call belongs to (ghost = 0, API = 1,
+    // selection rewrite = 2). `params`
     // configures the sampler chain + stop policy. When `params.useEngineStopPolicy` is true the
     // legacy ghost decode loop runs (word buffering, sentence stops, maxWords); when false the raw
     // API decode loop runs (verbatim piece stream, stop-string scan, maxTokens-only termination).
@@ -368,7 +400,12 @@ final class InferenceEngine: InferenceEngineProtocol {
             if params.fim != nil {
                 throw InferenceError.fimContextOverflow(tokens: tokens.count, cap: cap)
             }
-            tokens = Array(tokens.suffix(cap))
+            // The raw path front-trims (most-recent-context wins), but NOT with a plain suffix: that
+            // dropped the BOS that tokenize(addSpecial: true) put at index 0, and Gemma-3 — the
+            // shipping default — is trained with a mandatory BOS. Keep slot 0 whenever this vocab
+            // actually prepends one, and anchor the window so the head stays byte-stable between
+            // re-anchors (see trimToWindow).
+            tokens = Self.trimToWindow(tokens, cap: cap, keepFirst: llama_vocab_get_add_bos(vocab))
         }
 
         // Per-seq cached stream + KV length. First call on a seq starts empty. The defer below
@@ -477,12 +514,14 @@ final class InferenceEngine: InferenceEngineProtocol {
         // --- Decode loop ------------------------------------------------------------------------
         // Reusable candidate buffer for manual sample-with-probability (avoids a per-token vocab-sized
         // alloc; the decode budget is tiny — maxTokens). `cur.data` is modified in place by the chain.
+        // The buffer itself is a stored property (see `cand`) so it also survives across generate()
+        // calls; refill is per-token anyway, so only the size has to match the live vocab.
         let nVocab = Int(llama_vocab_n_tokens(vocab))
-        var cand = [llama_token_data](repeating: llama_token_data(id: 0, logit: 0, p: 0), count: nVocab)
+        if cand.count != nVocab {
+            cand = [llama_token_data](repeating: llama_token_data(id: 0, logit: 0, p: 0), count: nVocab)
+        }
 
         if params.useEngineStopPolicy {
-            // Tier 2a: build the byte table once before a healed (required-prefix) completion.
-            if let rp = requiredPrefix, !rp.isEmpty { ensureTokenByteTable(nVocab: nVocab) }
             try ghostDecodeLoop(ctx: ctx, vocab: vocab, smpl: smpl, batch: &batch,
                                 seqID: seqID, maxTokens: maxTokens,
                                 cached: &cached, nPast: &nPast,
@@ -739,6 +778,14 @@ final class InferenceEngine: InferenceEngineProtocol {
         modelArchitecture = nil
         modelSupportsChat = false
         modelFIMTokens = nil
+        // Tier 2a: the byte table is vocab-specific. reloadModel() is unload+load on this same
+        // instance, so leaving it behind hands the next model the previous vocab's bytes (see
+        // tokenByteBuf for what that breaks). Same for the vocab-sized candidate buffer, which
+        // generate() re-sizes on mismatch anyway but should not hold ~3 MB across an unload.
+        tokenByteBuf.removeAll(keepingCapacity: false)
+        tokenByteOff.removeAll(keepingCapacity: false)
+        tokenByteTableReady = false
+        cand.removeAll(keepingCapacity: false)
         cachedTokensBySeq.removeAll(keepingCapacity: false)
         nPastBySeq.removeAll(keepingCapacity: false)
         isLoaded = false
@@ -754,6 +801,16 @@ final class InferenceEngine: InferenceEngineProtocol {
         _ = llama_memory_seq_rm(memory, seqID, 0, -1)
     }
 
+    // Hand a sequence's KV cells back to the shared pool (see the protocol declaration for why). Safe to
+    // call on a seq that was never used. Must run on the inferenceQueue like every other engine call —
+    // it mutates the same per-seq maps generate() maintains.
+    func releaseSeq(_ seqID: Int32) {
+        guard isLoaded, let ctx else { return }
+        resetSeq(seqID, in: llama_get_memory(ctx))
+        cachedTokensBySeq[seqID] = nil
+        nPastBySeq[seqID] = nil
+    }
+
     // How many leading tokens of `new` are already committed to the KV cache holding `cached` —
     // the longest common prefix, but never the entire `new` stream: we keep at most new.count-1 so
     // the final token is always (re)evaluated to produce fresh sampling logits even when the prompt
@@ -767,6 +824,47 @@ final class InferenceEngine: InferenceEngineProtocol {
         var i = 0
         while i < cached.count, i < maxKeep, cached[i] == new[i] { i += 1 }
         return i
+    }
+
+    // Granularity of the front-trim window (FIX 4). See trimToWindow.
+    static let trimAnchor = 256
+
+    // Front-trim an over-cap prompt to the most recent `cap` tokens, ANCHORED — and keeping token 0
+    // when the vocab prepended a BOS (`keepFirst`).
+    //
+    // Why anchored: a plain `suffix(cap)` slides the window forward by one token per keystroke, so
+    // cached[0] != new[0] on every fire, reuseLength() returns 0, resetSeq() runs, and every single
+    // keystroke pays a full cold prefill. That is why the documented warm ~65 ms path (FR-CE-5)
+    // vanishes in long documents — the exact case the product exists for. Rounding the dropped-token
+    // count UP to a multiple of `trimAnchor` pins the window head to a fixed grid: between re-anchors
+    // the prompt head is byte-identical, reuseLength grows normally, and one cold prefill is amortized
+    // over ~256 tokens of typing. (Rounding DOWN would keep more tokens than `cap` allows and blow the
+    // n_ctx budget the cap exists to protect, so it has to be up.) The price is that the live window
+    // oscillates in (cap - anchor, cap] instead of sitting at cap — ~6% of context at 3840/256.
+    //
+    // Upgrade path for the next reader: llama_memory_seq_add + llama_memory_can_shift DO exist in this
+    // build (llama.h:736, :769), so a true server-style seq_rm+seq_add context shift — rebasing the KV
+    // positions instead of re-prefilling — is possible. We deliberately take the anchored window first:
+    // it is a fraction of the work and captures most of the win.
+    //
+    // llama_token is a typealias for Int32; spelled Int32 so this stays callable from the test target
+    // without importing CLlama.
+    static func trimToWindow(_ tokens: [Int32], cap: Int, keepFirst: Bool) -> [Int32] {
+        guard cap > 0, tokens.count > cap else { return tokens }
+        let head = keepFirst ? 1 : 0            // slots reserved at the front (BOS)
+        guard tokens.count > head else { return tokens }
+        // Scale the step down on small windows so one anchor step can never cost more than a quarter
+        // of the context (at the shipping cap of 3840 this is a no-op and the step stays 256).
+        let anchor = max(1, min(trimAnchor, cap / 4))
+        // Body tokens that MUST go for the result (head + kept body) to fit `cap`; the head is carried
+        // over, so the shortfall is the same with or without a BOS.
+        let minDrop = tokens.count - cap
+        let drop = min(((minDrop + anchor - 1) / anchor) * anchor, tokens.count - head)
+        var out: [Int32] = []
+        out.reserveCapacity(tokens.count - drop)
+        if keepFirst { out.append(tokens[0]) }
+        out.append(contentsOf: tokens[(head + drop)...])
+        return out
     }
 
     // First stop-string occurrence in `s` across any of `stops`. Returns the index of the EARLIEST

--- a/Sources/Shadowtype/InferenceEngine.swift
+++ b/Sources/Shadowtype/InferenceEngine.swift
@@ -36,6 +36,12 @@ enum InferenceError: Error, LocalizedError {
     // failure, so the request is refused; routes should surface it as HTTP 400 (fixable by the
     // caller: shorten the prompt or lower max_tokens).
     case promptWindowExhausted(tokens: Int, cap: Int, maxTokens: Int)
+    // The caller passed an explicit `contextTokenCap` (today only the /v1 API path, which asks for the
+    // engine's REAL window rather than the ghost's small one) and the prompt still doesn't fit. There is
+    // no larger window left to fall back to, so front-trimming here would silently drop the head of a
+    // request the caller believes was honored — for a chat prompt that is the system message. Refuse
+    // instead; routes surface it as HTTP 400. The ghost and rewrite paths pass no cap and keep trimming.
+    case contextOverflow(tokens: Int, cap: Int)
 
     var errorDescription: String? {
         switch self {
@@ -47,6 +53,8 @@ enum InferenceError: Error, LocalizedError {
         case .fimContextOverflow(let t, let cap): return "Context overflow: \(t) tokens exceed the \(cap)-token cap."
         case .promptWindowExhausted(let t, let cap, let mt):
             return "Prompt is \(t) tokens but only \(cap) fit alongside max_tokens=\(mt) — shorten the prompt or lower max_tokens."
+        case .contextOverflow(let t, let cap):
+            return "Prompt is \(t) tokens but the context window fits \(cap) — shorten the prompt."
         }
     }
 }
@@ -215,6 +223,16 @@ final class InferenceEngine: InferenceEngineProtocol {
     // Mirrored from @AppStorage by AppDelegate.syncToggles.
     var maxContextTokens: Int = 4096
 
+    // The window the context was actually created with, independent of the ghost's `maxContextTokens`
+    // setting. `llama_n_ctx` once a context exists (it can differ from `contextSize` — llama rounds it
+    // to the batch/seq layout), otherwise the size the next load will request. The API path sizes its
+    // per-call cap from this so a 3000-token editor request is no longer front-trimmed to the ghost's
+    // 1024-token setting, and /v1/health advertises it instead of the old hardcoded 4096.
+    var contextWindowTokens: Int {
+        if let ctx { return Int(llama_n_ctx(ctx)) }
+        return Int(contextSize)
+    }
+
     init() {}
 
     deinit { unload() }
@@ -354,9 +372,28 @@ final class InferenceEngine: InferenceEngineProtocol {
     // configures the sampler chain + stop policy. When `params.useEngineStopPolicy` is true the
     // legacy ghost decode loop runs (word buffering, sentence stops, maxWords); when false the raw
     // API decode loop runs (verbatim piece stream, stop-string scan, maxTokens-only termination).
+    //
+    // Witness for the protocol's uncapped call shape (ghost seq 0, rewrite seq 2). A nil cap is
+    // "use the engine-wide maxContextTokens", i.e. byte-identical to the pre-cap behaviour.
+    func generate(prompt: String, maxTokens: Int,
+                  seqID: Int32, params: SamplingParams,
+                  requiredPrefix: [UInt8]?,
+                  onToken: (String) -> Bool,
+                  onSample: ((_ prob: Float, _ isFirstContent: Bool) -> Void)?) throws {
+        try generate(prompt: prompt, maxTokens: maxTokens, seqID: seqID, params: params,
+                     contextTokenCap: nil, requiredPrefix: requiredPrefix,
+                     onToken: onToken, onSample: onSample)
+    }
+    //
+    // `contextTokenCap` overrides the engine-wide `maxContextTokens` for THIS call only. Ghost and
+    // rewrite pass nil and keep the user's "Context window size"; the API path passes the real window
+    // (see contextWindowTokens) so an editor's long request is not silently cut down to the ghost's
+    // setting. A non-nil cap also makes an over-cap prompt an ERROR rather than a front-trim — see
+    // InferenceError.contextOverflow.
     func generate(prompt: String, maxTokens: Int,
                   seqID: Int32 = 0,
                   params: SamplingParams = .ghostDefaults,
+                  contextTokenCap: Int?,
                   requiredPrefix: [UInt8]? = nil,
                   onToken: (String) -> Bool,
                   onSample: ((_ prob: Float, _ isFirstContent: Bool) -> Void)? = nil) throws {
@@ -398,7 +435,8 @@ final class InferenceEngine: InferenceEngineProtocol {
         // generate (see generationReserve): it used to be a flat 256 while /v1 admits max_tokens up to
         // 2048, so a prompt at the cap plus 2048 generated tokens overran the 4096 pool and the stream
         // died mid-response with a 500.
-        let cap = Self.promptCap(nCtx: nCtx, maxTokens: maxTokens, maxContextTokens: maxContextTokens)
+        let cap = Self.promptCap(nCtx: nCtx, maxTokens: maxTokens,
+                                 maxContextTokens: contextTokenCap ?? maxContextTokens)
         if tokens.count > cap {
             // M5 review #2: refuse to truncate when the prompt is a FIM token stream — front-trim
             // drops `fim_pre` first (and on tighter caps `fim_suf`), leaving the model with framing
@@ -416,6 +454,13 @@ final class InferenceEngine: InferenceEngineProtocol {
             // deliberately set a small "Context window size" still gets the trim they asked for.
             if nCtx - Self.generationReserve(maxTokens: maxTokens) < Self.minPromptWindow {
                 throw InferenceError.promptWindowExhausted(tokens: tokens.count, cap: cap, maxTokens: maxTokens)
+            }
+            // An explicit cap means the caller already asked for the largest window there is, so the
+            // over-cap prompt is a genuine overflow rather than the ghost's deliberate recall/latency
+            // trade. Front-trimming it would drop the HEAD — the system message of a chat request — and
+            // still answer HTTP 200, which is the silent-truncation bug this refuses to reintroduce.
+            if contextTokenCap != nil {
+                throw InferenceError.contextOverflow(tokens: tokens.count, cap: cap)
             }
             // The raw path front-trims (most-recent-context wins), but NOT with a plain suffix: that
             // dropped the BOS that tokenize(addSpecial: true) put at index 0, and Gemma-3 — the

--- a/Sources/Shadowtype/InferenceEngineProtocol.swift
+++ b/Sources/Shadowtype/InferenceEngineProtocol.swift
@@ -44,6 +44,13 @@ protocol InferenceEngineProtocol: AnyObject {
     func unload()
     func requestCancel()
 
+    // Drop a sequence's KV cells and cached token stream. `kv_unified = true` means every seq draws from
+    // ONE n_ctx-sized pool, so a seq that will never reuse its prefix should hand the cells back rather
+    // than hold them against the ghost: ghost + rewrite both prefilling near the cap would otherwise ask
+    // for more cells than exist and `llama_decode` fails with no KV slot. Rewrite is exactly that case —
+    // every rewrite prompt diverges at token 0, so its cache is never reused.
+    func releaseSeq(_ seqID: Int32)
+
     // Full-surface generate. Ghost callers use the defaulted extension below (`seqID: 0`,
     // `params: .ghostDefaults`); API/MCP callers stamp their own seq ID + clamped params so the two
     // workloads can coexist in the same context with independent KV slots.
@@ -122,6 +129,7 @@ final class InferenceEngineRouter: InferenceEngineProtocol {
     func load(modelPath: String) throws { try active.load(modelPath: modelPath) }
     func unload() { active.unload() }
     func requestCancel() { active.requestCancel() }
+    func releaseSeq(_ seqID: Int32) { active.releaseSeq(seqID) }
 
     func generate(prompt: String, maxTokens: Int,
                   seqID: Int32, params: SamplingParams,
@@ -156,6 +164,7 @@ final class FoundationModelsEngine: InferenceEngineProtocol {
 
     func unload() {}
     func requestCancel() {}
+    func releaseSeq(_ seqID: Int32) {}
 
     func generate(prompt: String, maxTokens: Int,
                   seqID: Int32, params: SamplingParams,

--- a/Sources/Shadowtype/InferenceEngineProtocol.swift
+++ b/Sources/Shadowtype/InferenceEngineProtocol.swift
@@ -61,9 +61,48 @@ protocol InferenceEngineProtocol: AnyObject {
                   requiredPrefix: [UInt8]?,
                   onToken: (String) -> Bool,
                   onSample: ((_ prob: Float, _ isFirstContent: Bool) -> Void)?) throws
+
+    // The engine's REAL context window, as opposed to `maxContextTokens` — which is engine-WIDE but is
+    // driven from the GHOST's "Context window size" setting (1024 by default). Because generate()
+    // applies that cap with no reference to seqID, a 3000-token Cursor/Claude Code request on seq 1 is
+    // silently front-trimmed to the last 1024 tokens — the system prompt is dropped — and still returns
+    // HTTP 200, while /v1/health advertises the full window. The API path reads this to size its own
+    // cap. Declared here (not only in the extension) so a backend CAN override it: InferenceEngine
+    // reports its live `llama_n_ctx`, and the extension default below (the engine-wide setting) is the
+    // conservative fallback for a backend that has no separate notion of a window.
+    var contextWindowTokens: Int { get }
+
+    // Per-call prompt cap. `contextTokenCap` overrides the engine-wide `maxContextTokens` for THIS call
+    // only, so the ghost keeps the user's small window while an API request gets the real one. A
+    // requirement rather than extension-only so a backend that implements it is dispatched to
+    // dynamically — InferenceEngine threads it into `promptCap` and turns an over-cap prompt into
+    // `InferenceError.contextOverflow` (HTTP 400) instead of a silent front-trim. The extension default
+    // below ignores the cap and forwards to the engine-wide path, for backends that have no such notion.
+    func generate(prompt: String,
+                  maxTokens: Int,
+                  seqID: Int32,
+                  params: SamplingParams,
+                  contextTokenCap: Int?,
+                  requiredPrefix: [UInt8]?,
+                  onToken: (String) -> Bool,
+                  onSample: ((_ prob: Float, _ isFirstContent: Bool) -> Void)?) throws
 }
 
 extension InferenceEngineProtocol {
+    var contextWindowTokens: Int { maxContextTokens }
+
+    func generate(prompt: String,
+                  maxTokens: Int,
+                  seqID: Int32,
+                  params: SamplingParams,
+                  contextTokenCap: Int?,
+                  requiredPrefix: [UInt8]?,
+                  onToken: (String) -> Bool,
+                  onSample: ((_ prob: Float, _ isFirstContent: Bool) -> Void)?) throws {
+        try generate(prompt: prompt, maxTokens: maxTokens, seqID: seqID, params: params,
+                     requiredPrefix: requiredPrefix, onToken: onToken, onSample: onSample)
+    }
+
     // Legacy ghost-text shape. Forwards to the new method with `seq 0` + `.ghostDefaults` so all
     // existing call sites (CompletionCoordinator.startGeneration / rewrite / warmFocus) remain
     // source-compatible and byte-identical in behavior.
@@ -125,6 +164,7 @@ final class InferenceEngineRouter: InferenceEngineProtocol {
     var modelArchitecture: String? { active.modelArchitecture }
     var modelSupportsChat: Bool { active.modelSupportsChat }
     var supportsFIM: Bool { active.supportsFIM }
+    var contextWindowTokens: Int { active.contextWindowTokens }
 
     func load(modelPath: String) throws { try active.load(modelPath: modelPath) }
     func unload() { active.unload() }
@@ -138,6 +178,21 @@ final class InferenceEngineRouter: InferenceEngineProtocol {
                   onSample: ((_ prob: Float, _ isFirstContent: Bool) -> Void)?) throws {
         try active.generate(prompt: prompt, maxTokens: maxTokens,
                             seqID: seqID, params: params,
+                            requiredPrefix: requiredPrefix,
+                            onToken: onToken, onSample: onSample)
+    }
+
+    // Forwarded explicitly so the per-call cap reaches the backend that implements it; a backend that
+    // doesn't picks up the protocol extension's default (ignore + forward) at this call site.
+    func generate(prompt: String, maxTokens: Int,
+                  seqID: Int32, params: SamplingParams,
+                  contextTokenCap: Int?,
+                  requiredPrefix: [UInt8]?,
+                  onToken: (String) -> Bool,
+                  onSample: ((_ prob: Float, _ isFirstContent: Bool) -> Void)?) throws {
+        try active.generate(prompt: prompt, maxTokens: maxTokens,
+                            seqID: seqID, params: params,
+                            contextTokenCap: contextTokenCap,
                             requiredPrefix: requiredPrefix,
                             onToken: onToken, onSample: onSample)
     }

--- a/Sources/Shadowtype/LocalAPIRoutes.swift
+++ b/Sources/Shadowtype/LocalAPIRoutes.swift
@@ -42,10 +42,14 @@ enum LocalAPIRoutes {
         let active = activeModelName()
         let supportsFIM = server.coordinator?.modelSupportsFIM ?? false
         let supportsChat = server.coordinator?.modelSupportsChat ?? false
+        // `ctx` is what an API request actually gets, read from the engine — NOT the hardcoded 4096 it
+        // used to be, and NOT the ghost's `maxContextTokens` (that is the user's "Context window size"
+        // setting, 1024 by default). Advertising a window larger than the one the decode applies is how
+        // a client ends up sending a 3000-token request that comes back silently front-trimmed.
         let body: [String: Any] = [
             "ok": loaded,
             "model": active,
-            "ctx": 4096,
+            "ctx": server.coordinator?.apiContextTokens ?? 0,
             "supports_fim": supportsFIM,
             "supports_chat": supportsChat,
             "version": appShortVersion(),
@@ -445,6 +449,17 @@ enum LocalAPIRoutes {
             if case InferenceError.fimContextOverflow(let toks, let cap) = inner {
                 return (400, "Bad Request",
                         "FIM prompt+suffix tokenizes to \(toks) tokens but max context is \(cap) — shorten prefix or suffix")
+            }
+            // Same reasoning for a plain over-long prompt: the API path asks the engine for its real
+            // window, so an over-cap prompt has nowhere left to fit. Returning 200 with a front-trimmed
+            // prompt loses the head — the system message — without telling the client, so say 400.
+            if case InferenceError.contextOverflow(let toks, let cap) = inner {
+                return (400, "Bad Request",
+                        "prompt tokenizes to \(toks) tokens but max context is \(cap) — shorten the prompt")
+            }
+            if case InferenceError.promptWindowExhausted(let toks, let cap, let mt) = inner {
+                return (400, "Bad Request",
+                        "prompt tokenizes to \(toks) tokens but only \(cap) fit alongside max_tokens=\(mt) — shorten the prompt or lower max_tokens")
             }
             return (500, "Server Error", "decode failed")
         }

--- a/Sources/Shadowtype/MidWordHealing.swift
+++ b/Sources/Shadowtype/MidWordHealing.swift
@@ -17,15 +17,29 @@ enum MidWordHealing {
         c.isLetter || c.isNumber || c == "_"
     }
 
+    // Longest stem healed when the caret sits in a space-less script (CJK / kana / Thai). There the
+    // trailing word-char run is not a word but everything since the last full stop — routinely 10-24
+    // chars — and every stem-consuming token still counts against the engine's maxTokens (16 at the
+    // medium preset), so healing the whole run spends most of the generation budget re-emitting text
+    // the user already typed. A few characters are enough to steer the word the caret is inside.
+    static let maxSpacelessStem = 4
+
     // Split `prefix` into (head, stem) when it ends mid-word: `stem` is the trailing run of word
     // chars, `head` is everything before it (ending at the last boundary). nil when the caret is not
     // mid-word (prefix ends in whitespace/punctuation, or there's no word run), or the stem is longer
     // than `maxStem` (a long run is almost certainly a complete word — healing it just burns the
-    // constraint for no gain, and risks reconstructing a different long word).
+    // constraint for no gain, and risks reconstructing a different long word). A space-less-script run
+    // is trimmed to `maxSpacelessStem` instead of rejected: whitespace never breaks it, so the
+    // `maxStem` rule would either reject every healed CJK caret or heal a whole clause.
     static func split(prefix: String, maxStem: Int = 24) -> Split? {
         guard let last = prefix.last, isWordChar(last) else { return nil }
-        let stem = String(prefix.reversed().prefix(while: isWordChar).reversed())
-        guard !stem.isEmpty, stem.count <= maxStem else { return nil }
+        var stem = String(prefix.reversed().prefix(while: isWordChar).reversed())
+        guard !stem.isEmpty else { return nil }
+        if SentenceBoundary.isSpacelessScript(last) {
+            stem = String(stem.suffix(maxSpacelessStem))
+        } else if stem.count > maxStem {
+            return nil
+        }
         return Split(head: String(prefix.dropLast(stem.count)), stem: stem)
     }
 

--- a/Sources/Shadowtype/ModelCatalog.swift
+++ b/Sources/Shadowtype/ModelCatalog.swift
@@ -6,9 +6,11 @@
 // is false, and a live model swap on selection.
 //
 // Honesty about checksums: `sha256` is OPTIONAL. A pinned hash is only ever set for an LFS object we
-// have actually downloaded and verified ourselves (the existing default model). For the larger entries
-// we ship `nil` — meaning "no pinned hash yet, skip checksum with a logged warning" — rather than
-// inventing a hash we cannot stand behind. The integrator pins these at release time once verified.
+// have actually downloaded and verified ourselves (the existing default model); for the larger entries
+// we ship `nil` rather than inventing a hash we cannot stand behind. `nil` no longer means "unchecked":
+// ModelManager falls back to the SHA-256 Hugging Face reports for the LFS object (`X-Linked-Etag`) and
+// only drops to a GGUF-magic sanity check when that header is absent — and it reports which of the
+// three happened via `lastVerification`, so the UI never overclaims.
 import Foundation
 
 /// FR-LM-1: one selectable local model. `Identifiable` (stable `id`) so SwiftUI/AppKit lists can key on
@@ -22,8 +24,9 @@ struct ModelCatalogEntry: Identifiable, Hashable {
     let fileName: String
     /// HTTPS `resolve` URL of the GGUF LFS object on Hugging Face.
     let url: URL
-    /// Lowercase hex SHA-256 of the LFS object, or nil when no hash is pinned yet (skip checksum,
-    /// log a warning). We only ever pin hashes we have verified ourselves.
+    /// Lowercase hex SHA-256 of the LFS object, or nil when no hash is pinned yet — in which case
+    /// ModelManager verifies against the server-reported `X-Linked-Etag` instead. We only ever pin
+    /// hashes we have verified ourselves; a pin always WINS over the header (see verificationPlan).
     let sha256: String?
     /// Approximate resident memory (GiB) the loaded model needs; drives the RAM gate (PRD §6).
     let approxRAMGB: Double
@@ -31,6 +34,12 @@ struct ModelCatalogEntry: Identifiable, Hashable {
     let downloadGB: Double
     /// Legacy field, always false; no gate. Kept so callers/tests that still set it compile.
     let paidOnly: Bool
+    /// Quantization format of THIS file, read off its actual filename ("Q4_K_M", "Q4_0"), or nil when
+    /// unknown (BYOM imports, whose filename is the user's). The model cards used to hardcode "Q4_K_M"
+    /// for every row, which mislabeled the four Google QAT `q4_0` GGUFs; the UI must render this field
+    /// instead of a constant. Declared after `paidOnly` so the memberwise init keeps its existing
+    /// argument order for the call sites that don't set it (ImportedModelStore, tests).
+    var quant: String? = nil
     /// True when the GGUF is an *instruct* model (no base/pretrained variant exists for it). Instruct
     /// models are trained to end their turn, so on a dangling or complete-looking prefix they emit
     /// end-of-turn and the ghost shows nothing — worst on non-English text (bug 3, confirmed unfixable
@@ -43,12 +52,13 @@ struct ModelCatalogEntry: Identifiable, Hashable {
 /// FR-LM-1/2/3: the curated catalog plus RAM-fit logic. Static-only; there is no instance state.
 enum ModelCatalog {
     /// The selectable models — every entry is FREE (`paidOnly:false`). The first entry is the shipping
-    /// default (its known, verified hash is kept); the rest are real, reputable Q4_K_M GGUFs from the
-    /// trusted llama.cpp quant repos we already use (bartowski, mradermacher). Qwen3 entries use the
+    /// default (its known, verified hash is kept); the rest are real, reputable GGUFs from trusted
+    /// sources — community Q4_K_M re-quants (mradermacher) and Google's own QAT `q4_0` builds. Each
+    /// entry records its actual format in `quant`; do not assume Q4_K_M. Qwen3 entries use the
     /// *Base* (pretrained, NOT instruct) GGUFs so they continue text under the raw-prefix prompt path
-    /// (no chat template) instead of chatting — same rationale as the Gemma 3 base default; Gemma E2B/
-    /// E4B and the MoE entries fall back to instruct fed raw-prefix (no base GGUF exists), matching the
-    /// existing Gemma 4 E2B / Llama precedent. All non-default `sha256` are `nil` until pinned at release
+    /// (no chat template) instead of chatting — same rationale as the Gemma 3 base default; the Gemma 4
+    /// entries fall back to instruct fed raw-prefix because no base GGUF exists for them at all.
+    /// All non-default `sha256` are `nil` until pinned at release
     /// — we do not hallucinate hashes. `downloadGB` is the verified LFS Content-Length. Ordered
     /// small→large by `approxRAMGB` so RAM-fit selection (`recommended`) reads naturally.
     static let entries: [ModelCatalogEntry] = [
@@ -62,7 +72,8 @@ enum ModelCatalog {
             sha256: ModelManager.defaultModelSHA256,
             approxRAMGB: 1.5,
             downloadGB: 0.8,   // 806 MB LFS object (verified)
-            paidOnly: false
+            paidOnly: false,
+            quant: "Q4_K_M"
         ),
         // Qwen 3 1.7B BASE (pretrained) Q4_K_M, from mradermacher's ungated GGUF repo.
         ModelCatalogEntry(
@@ -74,7 +85,8 @@ enum ModelCatalog {
             sha256: nil,
             approxRAMGB: 2.0,
             downloadGB: 1.1,   // verified Content-Length
-            paidOnly: false
+            paidOnly: false,
+            quant: "Q4_K_M"
         ),
         // Qwen 3 4B BASE (pretrained) Q4_K_M, mradermacher.
         ModelCatalogEntry(
@@ -86,11 +98,22 @@ enum ModelCatalog {
             sha256: nil,
             approxRAMGB: 3.5,
             downloadGB: 2.5,   // verified Content-Length (2.49 GB)
-            paidOnly: false
+            paidOnly: false,
+            quant: "Q4_K_M"
         ),
         // NOTE: Gemma 3 4B BASE (pt) was removed from the catalog — quality bake-off testing
         // showed it REGRESSES close-language steering (Catalan → Spanish 3/4 seeds even
         // WITH the language steer, vs Gemma-1B 0/4) for 3× the size. Bigger ≠ better here.
+        //
+        // CAVEAT on the four `gemma-4-*-qat-q4_0` entries below (E2B, E4B, 12B, 26B-A4B): they are
+        // Q4_0 GGUFs *published from* QAT checkpoints, and a naive Q4_0 conversion from a QAT
+        // checkpoint throws most of the QAT benefit away — llama.cpp's Q4_0 stores F16 block scales
+        // while the QAT recipe trains against BF16 scales, so the trained scales are re-rounded.
+        // Vendor-published figures for that mismatch are ~70.2% vs ~85.6% top-1 (their numbers, NOT
+        // independently confirmed by us). We have NOT verified which conversion path produced these
+        // specific files, so the URLs stay as-is; if a Gemma 4 entry ever reads noticeably worse than
+        // its size suggests, re-quantize from the QAT checkpoint with BF16 scales and compare before
+        // blaming the prompt path.
         // Gemma 4 E2B — Google's OFFICIAL QAT Q4_0 GGUF (gemma-4-E2B-it-qat-q4_0-gguf). QAT
         // (quantization-aware training) preserves quality at Q4 far better than community PTQ Q4_K_M,
         // and ships smaller (3.35 vs 3.46 GB). MatFormer "effective-2B" on-device model. Still INSTRUCT
@@ -107,6 +130,7 @@ enum ModelCatalog {
             approxRAMGB: 4.4,
             downloadGB: 3.35,  // verified file size (Google QAT Q4_0)
             paidOnly: false,
+            quant: "Q4_0",
             isInstruct: true
         ),
         // Gemma 4 E4B — Google's OFFICIAL QAT Q4_0 GGUF. Larger MatFormer "effective-4B"; fed
@@ -121,6 +145,7 @@ enum ModelCatalog {
             approxRAMGB: 6.3,
             downloadGB: 5.15,  // verified file size (Google QAT Q4_0)
             paidOnly: false,
+            quant: "Q4_0",
             isInstruct: true
         ),
         // Qwen 3 8B BASE (pretrained) Q4_K_M, mradermacher.
@@ -133,21 +158,18 @@ enum ModelCatalog {
             sha256: nil,
             approxRAMGB: 6.8,
             downloadGB: 5.0,   // verified Content-Length (5.02 GB)
-            paidOnly: false
-        ),
-        // Meta Llama 3.1 8B Instruct, bartowski. Fed raw-prefix. Hash pinned at release.
-        ModelCatalogEntry(
-            id: "llama-3.1-8b-instruct-q4_k_m",
-            name: "Llama 3.1 8B Instruct",
-            fileName: "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
-            url: URL(string:
-                "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf")!,
-            sha256: nil,
-            approxRAMGB: 7.5,
-            downloadGB: 4.9,   // approximate; pinned at release
             paidOnly: false,
-            isInstruct: true
+            quant: "Q4_K_M"
         ),
+        // NOTE: Meta Llama 3.1 8B Instruct was removed — it was dominated on every axis a catalog entry
+        // has to earn: beaten by ~4B-class 2026 models while being twice their size, a 2023-12
+        // knowledge cutoff, the only non-Apache/permissive license in an otherwise clean catalog, and
+        // the only instruct entry that broke the base-variant-for-raw-continuation rule by choice (the
+        // Gemma 4 entries are instruct only because no base GGUF exists for them; a Llama 3.1 8B base
+        // does exist). Its approxRAMGB (7.5) also sat ABOVE qwen3-8b-base's 6.8 despite a SMALLER
+        // download, so it sorted last and `recommended` skipped it as instruct — it could only ever be
+        // reached by a mis-click.
+        //
         // Gemma 4 12B — Google's OFFICIAL QAT Q4_0 GGUF (released 2026-06-03). Dense, encoder-free
         // multimodal; bridges the gap between E4B (~6 GB) and the 26B MoE (~16 GB) that the catalog
         // previously jumped over. Fed raw-prefix (instruct). sha256 nil until pinned at release.
@@ -161,6 +183,7 @@ enum ModelCatalog {
             approxRAMGB: 8.5,
             downloadGB: 6.98,  // verified file size (Google QAT Q4_0)
             paidOnly: false,
+            quant: "Q4_0",
             isInstruct: true
         ),
         // Gemma 4 26B-A4B — Google's OFFICIAL QAT Q4_0 GGUF. Sparse MoE (~26B total / ~4B active).
@@ -177,10 +200,13 @@ enum ModelCatalog {
             approxRAMGB: 15.8,
             downloadGB: 14.4,  // verified file size (Google QAT Q4_0)
             paidOnly: false,
+            quant: "Q4_0",
             isInstruct: true
         ),
         // Qwen 3 30B-A3B BASE (pretrained) — sparse MoE (~30B total / ~3B active), mradermacher.
-        // Largest entry; RAM-gated into "Other models" except on high-RAM Macs.
+        // Largest entry; RAM-gated into "Other models" except on high-RAM Macs. Never recommended
+        // (see `recommendedCapRAMGB`) — it exists for the local API / manual power-user pick, where
+        // there is no 400 ms ghost deadline to miss.
         ModelCatalogEntry(
             id: "qwen3-30b-a3b-base-q4_k_m",
             name: "Qwen 3 30B A3B",
@@ -190,40 +216,84 @@ enum ModelCatalog {
             sha256: nil,
             approxRAMGB: 20.0,
             downloadGB: 18.6,  // verified Content-Length (18.55 GB)
-            paidOnly: false
+            paidOnly: false,
+            quant: "Q4_K_M"
         ),
     ]
 
-    /// FR-LM-2 (PRD §6): a model is RAM-OK only if its approximate footprint stays within ~75% of
-    /// physical RAM. Beyond that the Models pane warns/blocks (loading would thrash or OOM). Uses GB
-    /// (1e9) to match the human-facing `approxRAMGB` figures. `physicalBytes` is injectable so tests can
-    /// pass synthetic machine sizes (no `ProcessInfo` dependency here).
+    /// GB (1e9) macOS itself plus whatever app the user is typing into needs to stay resident. The
+    /// budget used to be a flat 75% of RAM, which on an 8 GB Mac left 6.44 GB for the model and nothing
+    /// for the system — so the 6.3 GB E4B entry reported RAM-OK and never got the "Tight on RAM" tag,
+    /// while in practice it swaps. On Apple Silicon the GPU draws from this SAME unified pool, so there
+    /// is no separate VRAM to fall back on.
+    private static let osReserveGB = 3.0
+
+    /// Fraction of `approxRAMGB` to add for the F16 KV cache at the engine's n_ctx = 4096
+    /// (InferenceEngine.contextSize). KV bytes are 2 · n_layer · n_kv_head · head_dim · 2 at F16, which
+    /// tracks model size closely enough for a gate: measured ≈0.11 GB for Gemma-3-1B (1.5 GB weights)
+    /// and ≈0.60 GB for Qwen3-8B (6.8 GB weights) — both ≈8%. 10% is the conservative round number.
+    /// Deliberately a ratio and not a per-model table: this is a warning threshold, not an allocator.
+    private static let kvCacheFraction = 0.10
+
+    /// FR-LM-2 (PRD §6): a model is RAM-OK only if its WEIGHTS PLUS KV CACHE fit the machine's budget,
+    /// where the budget is the tighter of ~75% of physical RAM (the original headroom rule, binding on
+    /// big Macs) and "everything except the OS floor" (binding on 8 GB Macs). Beyond that the Models
+    /// pane warns. Uses GB (1e9) to match the human-facing `approxRAMGB` figures. `physicalBytes` is
+    /// injectable so tests can pass synthetic machine sizes (no `ProcessInfo` dependency here).
     static func ramOK(for entry: ModelCatalogEntry, physicalBytes: UInt64) -> Bool {
-        let needed = entry.approxRAMGB * 1e9
-        let budget = 0.75 * Double(physicalBytes)
+        let physicalGB = Double(physicalBytes) / 1e9
+        let needed = entry.approxRAMGB * (1.0 + kvCacheFraction)
+        let budget = min(0.75 * physicalGB, physicalGB - osReserveGB)
         return needed <= budget
     }
 
-    /// FR-LM-3: the best default for this machine — the largest entry that comfortably fits in RAM,
-    /// falling back to the smallest entry when nothing fits (so we always return something to load).
-    /// "Largest/smallest" is by `approxRAMGB`. `entries` is guaranteed non-empty. Every model is free,
-    /// so the whole catalog is always a candidate.
+    /// Largest `approxRAMGB` the RECOMMENDATION will ever pre-select, by machine class. This is a
+    /// deliberate product decision, not a bug fix — do NOT "optimize" it back to largest-that-fits.
+    ///
+    /// Shadowtype is a LATENCY product: the coordinator drops the ghost if the first token misses its
+    /// ~400 ms deadline on a ~1500-token prompt. A 30B MoE cannot clear that deadline, so on a 32 GB
+    /// Mac the old "largest that fits" rule pre-selected an 18.6 GB download that then showed NO ghost
+    /// at all — the product reads as broken. The objective is "best quality that clears the first-token
+    /// deadline", not "largest that fits".
+    /// Bigger is also not reliably better on quality here: see the Gemma 3 4B note above — the 4B base
+    /// REGRESSED Catalan→Spanish steering (3/4 seeds vs the 1B's 0/4) at 3× the size, which is why it
+    /// was removed from the catalog outright.
+    /// The large entries stay in the catalog and stay manually selectable — someone driving the local
+    /// API off a 30B has no ghost deadline to miss.
+    ///
+    /// >= 16 GB: the 4B class (qwen3-4b-base, 3.5 GB). Below that: the ~1.5 GB class (Gemma 3 1B) —
+    /// an 8 GB Mac is already sharing unified memory with the browser or editor being typed into, and
+    /// a swapping model misses the deadline just as surely as a slow one.
+    static func recommendedCapRAMGB(physicalBytes: UInt64) -> Double {
+        Double(physicalBytes) >= 16e9 ? 3.5 : 1.5
+    }
+
+    /// FR-LM-3: the best default for this machine — the largest entry that both fits in RAM and stays
+    /// under `recommendedCapRAMGB` (the first-token-deadline cap), falling back to the smallest entry
+    /// when nothing qualifies (so we always return something to load). "Largest/smallest" is by
+    /// `approxRAMGB`. `entries` is guaranteed non-empty. Every model is free, so the whole catalog is
+    /// always a candidate.
     static func recommended(physicalBytes: UInt64) -> ModelCatalogEntry {
         let candidates = entries
-        let fitting = candidates.filter { ramOK(for: $0, physicalBytes: physicalBytes) }
-        // Prefer the largest BASE model that fits. Base (pretrained) models continue raw-prefix text
+        let cap = recommendedCapRAMGB(physicalBytes: physicalBytes)
+        let fitting = candidates.filter {
+            $0.approxRAMGB <= cap && ramOK(for: $0, physicalBytes: physicalBytes)
+        }
+        // Prefer the largest BASE model under the cap. Base (pretrained) models continue raw-prefix text
         // reliably; instruct models emit end-of-turn on dangling/complete-looking prefixes and silently
         // drop the ghost (bug 3 — proven unfixable at the sampling layer). Picking the biggest-that-fits
-        // regardless of kind steered high-RAM Macs onto instruct models (e.g. Llama-3.1-8B-Instruct over
-        // the near-identical-size Qwen3-8B-Base), trading ghost-correctness for a fraction of a GB.
+        // regardless of kind steered high-RAM Macs onto instruct models (e.g. the removed
+        // Llama-3.1-8B-Instruct over the near-identical-size Qwen3-8B-Base), trading ghost-correctness
+        // for a fraction of a GB.
         if let bestBase = fitting.filter({ !$0.isInstruct }).max(by: { $0.approxRAMGB < $1.approxRAMGB }) {
             return bestBase
         }
-        // No base fits (only instruct models small enough): take the largest instruct that fits.
+        // No base qualifies (only instruct models are small enough): take the largest instruct.
         if let best = fitting.max(by: { $0.approxRAMGB < $1.approxRAMGB }) {
             return best
         }
-        // Nothing fits the 75% budget: pick the smallest available so the app still has a model to run.
+        // Nothing clears the RAM budget at all (a machine below the OS floor + smallest model): pick the
+        // smallest entry so the app still has a model to run, knowingly over budget.
         return candidates.min(by: { $0.approxRAMGB < $1.approxRAMGB }) ?? entries[0]
     }
 }

--- a/Sources/Shadowtype/ModelManager.swift
+++ b/Sources/Shadowtype/ModelManager.swift
@@ -11,6 +11,7 @@ enum ModelManagerError: LocalizedError {
     case checksumMismatch(expected: String, actual: String)
     case invalidModelFile(String)
     case insufficientDiskSpace(neededGB: Double, availableGB: Double)
+    case sizeMismatch(expected: Int64, actual: Int64)
 
     var errorDescription: String? {
         switch self {
@@ -29,8 +30,28 @@ enum ModelManagerError: LocalizedError {
         case .insufficientDiskSpace(let neededGB, let availableGB):
             return String(format: "Not enough disk space (need %.1f GB, %.1f GB available).",
                           neededGB, availableGB)
+        case .sizeMismatch(let expected, let actual):
+            return "Model download is incomplete (expected \(expected) bytes, got \(actual))."
         }
     }
+}
+
+/// What actually vouched for the bytes of the most recent download (FR-LM-2).
+///
+/// The onboarding copy told every user their model was "verified by checksum" while 9 of 11 catalog
+/// entries ship `sha256: nil` — for those the only check was the 4-byte GGUF magic, which a truncated
+/// or tampered multi-GB file passes trivially. The UI reads this to say what really happened.
+enum ModelVerification: Equatable {
+    /// Every byte hashed to the catalog's hand-pinned SHA-256.
+    case pinnedSHA256
+    /// Every byte hashed to the SHA-256 Hugging Face reports for the LFS object (`X-Linked-Etag`).
+    case linkedSHA256
+    /// No hash was available to check against (no pin, and no usable `X-Linked-Etag`): GGUF magic
+    /// only, plus the byte count when `X-Linked-Size` was present.
+    case unverified
+
+    /// True when a full SHA-256 over every byte matched — i.e. "verified by checksum" is honest.
+    var isHashVerified: Bool { self != .unverified }
 }
 
 final class ModelManager {
@@ -53,6 +74,11 @@ final class ModelManager {
 
     /// Progress callback: fraction in 0...1, or nil while total size is unknown.
     var onDownloadProgress: ((Double?) -> Void)?
+
+    /// How the most recent download was verified, or nil when this call downloaded nothing (the file
+    /// was already on disk). Exposed so the onboarding/Models UI states the truth instead of claiming
+    /// every model is "verified by checksum" — see `ModelVerification`.
+    private(set) var lastVerification: ModelVerification?
 
     func defaultModelURL() -> URL {
         return modelsDirectory().appendingPathComponent(Self.defaultModelFileName)
@@ -82,6 +108,15 @@ final class ModelManager {
            FileManager.default.fileExists(atPath: modelURL(for: entry).path) {
             return try await ensureModel(entry)   // present on disk → returns immediately, no download
         }
+        // The selection names a catalog entry that no longer exists (an id retired between releases —
+        // llama-3.1-8b-instruct was dropped in the 2026-07 catalog pass). Runtime already falls through
+        // safely, but leaving the dead id in defaults desynchronizes the Models pane: `selectedEntry`
+        // falls back to entries[0] and reports it Loaded, while every row's `entry.id == selectedID`
+        // check is false, so NO row shows the Active pill and the loaded model still offers "Use". Clear
+        // it so @AppStorage resolves to entries[0] and the pane agrees with itself again.
+        if let id, !id.hasPrefix("byom-"), !ModelCatalog.entries.contains(where: { $0.id == id }) {
+            UserDefaults.standard.removeObject(forKey: Self.selectedModelDefaultsKey)
+        }
         return try await ensureDefaultModel()
     }
 
@@ -98,10 +133,11 @@ final class ModelManager {
     }
 
     /// FR-LM-1/2: download (resumable) + SHA-verify any catalog entry, reusing the same download/hash
-    /// code as the default model. Returns early if the file is already present. When `entry.sha256` is
-    /// non-nil, verifies exactly like the default path (remove + throw `checksumMismatch` on mismatch);
-    /// when it is nil, SKIPS verification but logs a clear warning (PRD §6 honesty about checksums — the
-    /// paid entries ship with `sha256 == nil` until their real hashes are pinned at release).
+    /// code as the default model. Returns early if the file is already present. A pinned `entry.sha256`
+    /// wins; otherwise the SHA-256 Hugging Face reports for the LFS object (`X-Linked-Etag`, read off
+    /// the request we already make) is used, so entries with no pinned hash are still verified. Only
+    /// when neither exists do we fall back to the GGUF-magic check — and `lastVerification` then says
+    /// `.unverified` so the UI stops claiming a checksum was validated.
     @discardableResult
     func ensureModel(_ entry: ModelCatalogEntry) async throws -> URL {
         // M3 BYOM: imported entries live as local symlinks; no download/verify path. The import
@@ -113,13 +149,16 @@ final class ModelManager {
             guard FileManager.default.fileExists(atPath: target.path) else {
                 throw ModelManagerError.invalidModelFile(entry.id)
             }
+            lastVerification = nil
             return target
         }
         let destination = modelURL(for: entry)
         if FileManager.default.fileExists(atPath: destination.path) {
+            lastVerification = nil   // nothing was downloaded: don't report a stale verdict
             // A hash-pinned entry was verified before it was trusted; reuse it (re-hashing a multi-GB file
-            // every launch is too costly). A nil-hash entry has NO such guarantee, so a cheap GGUF-magic
-            // sanity check guards against a truncated/corrupt prior download being reused forever.
+            // every launch is too costly). For a nil-hash entry we cannot tell after the fact whether the
+            // download was header-verified — no verdict is persisted — so a cheap GGUF-magic sanity check
+            // still guards against a truncated/corrupt prior download being reused forever.
             if entry.sha256 != nil || Self.isValidGGUF(destination) { return destination }
             NSLog("[Shadowtype] WARNING: cached model \(entry.id) failed GGUF sanity check; re-downloading")
             try? FileManager.default.removeItem(at: destination)
@@ -130,25 +169,84 @@ final class ModelManager {
         // download die mid-flight (or fill the volume). Surfaces through the same error path as any
         // other download failure (.shadowtypeModelDidChange userInfo["error"]).
         try preflightDiskSpace(neededBytes: Int64(entry.downloadGB * 1e9))
-        try await download(from: entry.url, to: destination)
+        let result = try await download(from: entry.url, to: destination)
+        lastVerification = try verifyDownloaded(destination, id: entry.id,
+                                                pinnedSHA256: entry.sha256, result: result)
+        return destination
+    }
 
-        if let expected = entry.sha256 {
-            guard verifySHA256(destination, expected: expected) else {
-                let actual = (try? sha256Hex(of: destination)) ?? "<unreadable>"
+    /// Check the freshly-written bytes and report what actually vouched for them. Deletes the file and
+    /// throws on ANY mismatch — a bad multi-GB file must never reach engine.load, nor be reused as a
+    /// cached download forever. Ordered cheapest-first: 4-byte magic, then the byte count, then the
+    /// full hash (which re-reads the file in 1 MiB chunks — never all at once).
+    private func verifyDownloaded(_ destination: URL, id: String,
+                                  pinnedSHA256: String?, result: DownloadResult) throws -> ModelVerification {
+        // An HTML error page or an aborted transfer that still produced a file: reject before spending
+        // a full-file read on hashing it.
+        guard Self.isValidGGUF(destination) else {
+            try? FileManager.default.removeItem(at: destination)
+            throw ModelManagerError.invalidModelFile(id)
+        }
+        // Truncation is the common real-world failure and it sails past the magic check, so compare the
+        // byte count against `X-Linked-Size` whenever the server gave us one.
+        if let expectedSize = result.linkedSize {
+            let actualSize = (try? FileManager.default.attributesOfItem(atPath: destination.path)[.size]
+                              as? NSNumber)?.int64Value ?? -1
+            do {
+                try Self.checkDownloadedSize(expected: expectedSize, actual: actualSize)
+            } catch {
+                try? FileManager.default.removeItem(at: destination)
+                throw error
+            }
+        }
+        let plan = Self.verificationPlan(pinnedSHA256: pinnedSHA256, linkedSHA256: result.linkedSHA256)
+        if let expected = plan.expected {
+            let actual = (try? sha256Hex(of: destination)) ?? "<unreadable>"
+            guard actual.caseInsensitiveCompare(expected) == .orderedSame else {
                 try? FileManager.default.removeItem(at: destination)
                 throw ModelManagerError.checksumMismatch(expected: expected, actual: actual)
             }
         } else {
-            // No pinned hash (PRD §6 honesty): we can't verify the exact bytes, but we MUST reject a
-            // truncated download / HTML error page / non-model file before it reaches engine.load — so
-            // validate the GGUF magic header at minimum, and delete + throw on failure.
-            guard Self.isValidGGUF(destination) else {
-                try? FileManager.default.removeItem(at: destination)
-                throw ModelManagerError.invalidModelFile(entry.id)
-            }
-            NSLog("[Shadowtype] WARNING: no pinned SHA-256 for model \(entry.id); verified GGUF magic only")
+            NSLog("[Shadowtype] WARNING: \(id) has no pinned SHA-256 and the server sent no usable "
+                  + "X-Linked-Etag; verified GGUF magic only — NOT hash-verified")
         }
-        return destination
+        return plan.outcome
+    }
+
+    /// Pure decision: which hash the downloaded bytes must match, and what a match proves.
+    /// A catalog-pinned hash always wins over the server-reported one — the pin is the value we
+    /// audited ourselves, so if Hugging Face ever serves different bytes under the same URL that has
+    /// to be a hard failure, not a silently-accepted "the header agrees with itself".
+    static func verificationPlan(pinnedSHA256: String?,
+                                 linkedSHA256: String?) -> (expected: String?, outcome: ModelVerification) {
+        if let pinned = pinnedSHA256, !pinned.isEmpty { return (pinned, .pinnedSHA256) }
+        if let linked = linkedSHA256, !linked.isEmpty { return (linked, .linkedSHA256) }
+        return (nil, .unverified)
+    }
+
+    /// Pure size gate, split out so it's unit-testable without a download.
+    static func checkDownloadedSize(expected: Int64, actual: Int64) throws {
+        guard expected != actual else { return }
+        throw ModelManagerError.sizeMismatch(expected: expected, actual: actual)
+    }
+
+    /// Hugging Face reports the LFS object's real SHA-256 in `X-Linked-Etag` (quoted, occasionally with
+    /// a weak-validator prefix). Anything that is not exactly 64 ASCII hex chars is NOT a content hash
+    /// — small non-LFS files get an arbitrary/md5-shaped ETag — so reject it rather than "verify"
+    /// against a value that can never match. Pure + testable.
+    static func parseLinkedSHA256(_ raw: String?) -> String? {
+        guard var s = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty else { return nil }
+        if s.hasPrefix("W/") { s.removeFirst(2) }
+        s = s.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+        guard s.count == 64, s.allSatisfy({ $0.isASCII && $0.isHexDigit }) else { return nil }
+        return s.lowercased()
+    }
+
+    /// `X-Linked-Size` is the LFS object's byte count. Pure + testable.
+    static func parseLinkedSize(_ raw: String?) -> Int64? {
+        guard let s = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let n = Int64(s), n > 0 else { return nil }
+        return n
     }
 
     // Cheap integrity gate for nil-hash models: a real GGUF begins with the 4-byte ASCII magic "GGUF".
@@ -158,11 +256,6 @@ final class ModelManager {
         defer { try? handle.close() }
         let magic = try? handle.read(upToCount: 4)
         return magic == Data([0x47, 0x47, 0x55, 0x46])   // "GGUF"
-    }
-
-    func verifySHA256(_ url: URL, expected: String) -> Bool {
-        guard let actual = try? sha256Hex(of: url) else { return false }
-        return actual.caseInsensitiveCompare(expected) == .orderedSame
     }
 
     // MARK: - Disk-space preflight
@@ -203,14 +296,96 @@ final class ModelManager {
 
     // MARK: - Download
 
+    /// What the server told us about the object it served, captured from the SAME request we already
+    /// make: Hugging Face puts the LFS object's real SHA-256 in `X-Linked-Etag` and its byte count in
+    /// `X-Linked-Size`. That is what lets us verify EVERY entry instead of only the ones with a
+    /// hand-pinned hash.
+    private struct DownloadResult {
+        let linkedSHA256: String?
+        let linkedSize: Int64?
+    }
+
+    /// Where the resume blob for `destination` lives (`<file>.gguf.resume`), next to the download so a
+    /// user who deletes the model also drops its stale resume state.
+    static func resumeDataURL(for destination: URL) -> URL {
+        destination.appendingPathExtension("resume")
+    }
+
+    /// Resume blobs must be keyed by SOURCE as well as destination. `downloadTask(withResumeData:)`
+    /// ignores the request it is handed and continues the URL archived inside the blob, while HF
+    /// filenames are emphatically not unique across repos (`model.Q4_K_M.gguf` from mradermacher,
+    /// bartowski and unsloth all land on the same imported path). Keyed by destination alone, a
+    /// cancelled import of repo A leaves a blob that a later import of repo B's identically-named file
+    /// picks up — and silently downloads A's bytes under B's name. Folding a digest of the source in
+    /// means a blob for a different URL simply isn't found and the download restarts clean, which is
+    /// the correct outcome.
+    static func resumeDataURL(for destination: URL, source: URL) -> URL {
+        let digest = SHA256.hash(data: Data(source.absoluteString.utf8))
+            .prefix(4).map { String(format: "%02x", $0) }.joined()
+        return destination.appendingPathExtension(digest).appendingPathExtension("resume")
+    }
+
+    /// Sidecar holding the `X-Linked-*` values captured on the original `resolve` redirect, so a
+    /// resumed attempt — which never replays that hop — can still be size- and hash-checked. Kept
+    /// beside the resume blob rather than inside it so `isPlausibleResumeData` still validates the
+    /// opaque URLSession plist unchanged.
+    static func linkedMetadataURL(for resumeURL: URL) -> URL {
+        resumeURL.appendingPathExtension("meta")
+    }
+
+    struct LinkedMetadata: Codable, Equatable {
+        let sha256: String?
+        let size: Int64?
+        var isEmpty: Bool { sha256 == nil && size == nil }
+    }
+
+    static func writeLinkedMetadata(_ meta: LinkedMetadata, besideResumeAt resumeURL: URL) {
+        guard !meta.isEmpty, let data = try? JSONEncoder().encode(meta) else { return }
+        try? data.write(to: linkedMetadataURL(for: resumeURL), options: .atomic)
+    }
+
+    static func readLinkedMetadata(besideResumeAt resumeURL: URL) -> LinkedMetadata? {
+        guard let data = try? Data(contentsOf: linkedMetadataURL(for: resumeURL)),
+              let meta = try? JSONDecoder().decode(LinkedMetadata.self, from: data),
+              !meta.isEmpty else { return nil }
+        return meta
+    }
+
+    /// URLSession's resume blob is an opaque property list. Handing `downloadTask(withResumeData:)`
+    /// something that is not that plist has historically raised an ObjC exception (uncatchable from
+    /// Swift) instead of failing the task, so we check the shape first and treat anything else as
+    /// "no resume data". Pure + testable.
+    static func isPlausibleResumeData(_ data: Data) -> Bool {
+        guard !data.isEmpty,
+              let obj = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
+              let dict = obj as? [String: Any] else { return false }
+        return dict["NSURLSessionResumeInfoVersion"] != nil || dict["NSURLSessionDownloadURL"] != nil
+    }
+
+    /// Read a persisted resume blob, deleting it when it is unusable so a corrupt file can never wedge
+    /// the download at "always fails".
+    static func readResumeData(at url: URL) -> Data? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        guard isPlausibleResumeData(data) else {
+            try? FileManager.default.removeItem(at: url)
+            // The carried X-Linked-* describe the transfer this blob belonged to; a discarded blob
+            // means a clean restart, which will see the `resolve` redirect and capture them again.
+            try? FileManager.default.removeItem(at: linkedMetadataURL(for: url))
+            return nil
+        }
+        return data
+    }
+
+    /// Download `url` to `destination`, RESUMING a previously interrupted transfer when we have a
+    /// resume blob for it. A dropped connection at 90% of a 14 GB model used to restart from byte 0
+    /// (the async `download(for:)` convenience cannot hand back resume data on failure), which on a
+    /// metered or flaky link is the difference between usable and not.
+    @discardableResult
     private func download(from url: URL, to destination: URL,
-                          authorization: String? = nil) async throws {
+                          authorization: String? = nil) async throws -> DownloadResult {
         // Cooperative cancellation: a caller cancelling its Task (e.g. the HF import sheet's Cancel
         // button) must abort the transfer instead of completing + registering the import.
         try Task.checkCancellation()
-        let delegate = DownloadDelegate(onProgress: onDownloadProgress)
-        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-        defer { session.finishTasksAndInvalidate() }
 
         // M4 BYOM: optional Authorization header for HuggingFace gated/private repos. The token
         // is sourced from Keychain (APIKeyStore.huggingfaceToken), never UserDefaults / disk.
@@ -220,16 +395,63 @@ final class ModelManager {
             request.setValue(auth, forHTTPHeaderField: "Authorization")
         }
 
+        let resumeURL = Self.resumeDataURL(for: destination, source: url)
+        if let stored = Self.readResumeData(at: resumeURL) {
+            // Consume the blob: the delegate writes a FRESH one if this attempt also gets interrupted,
+            // so afterwards "a resume file exists" means "this attempt made progress worth keeping".
+            try? FileManager.default.removeItem(at: resumeURL)
+            do {
+                return try await runDownload(request: request, resumeData: stored,
+                                             to: destination, resumeURL: resumeURL)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                // A resume blob goes stale in ways the API does not distinguish: the tmp file it points
+                // at was purged, the object's ETag moved on, the blob was truncated by a crash. Those
+                // fail with no new resume data — restart clean rather than wedging the user forever.
+                // But when fresh resume data DID land, the transfer really was progressing and merely
+                // got interrupted again: keep it and report the failure, because restarting would throw
+                // away every byte the user already paid for.
+                if FileManager.default.fileExists(atPath: resumeURL.path) { throw error }
+                NSLog("[Shadowtype] resume data for \(destination.lastPathComponent) was unusable "
+                      + "(\(error.localizedDescription)); restarting the download from the beginning")
+                try Task.checkCancellation()
+            }
+        }
+        return try await runDownload(request: request, resumeData: nil,
+                                     to: destination, resumeURL: resumeURL)
+    }
+
+    /// One transfer attempt. Throws only `ModelManagerError` or `CancellationError`.
+    private func runDownload(request: URLRequest, resumeData: Data?,
+                             to destination: URL, resumeURL: URL) async throws -> DownloadResult {
+        // The download task has to be delegate-held (not `session.download(for:)`) precisely so the
+        // failure path can hand back resume data; the delegate persists it next to the partial file.
+        let staging = destination.appendingPathExtension("part")
+        let delegate = DownloadDelegate(onProgress: onDownloadProgress,
+                                        stagingURL: staging, resumeDataURL: resumeURL)
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+        let task = resumeData.map { session.downloadTask(withResumeData: $0) }
+            ?? session.downloadTask(with: request)
+
+        let finished: DownloadDelegate.Finished
         do {
-            let (tempURL, response) = try await session.download(for: request, delegate: delegate)
-            if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
-                throw ModelManagerError.serverError(statusCode: http.statusCode)
+            finished = try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { (cont: CheckedContinuation<DownloadDelegate.Finished, Error>) in
+                    delegate.attach(cont)
+                    task.resume()
+                }
+            } onCancel: {
+                // Cancel WITH resume data so the import sheet's Cancel (or an app quit) doesn't throw
+                // away a multi-GB partial transfer the user may well want to finish later.
+                task.cancel(byProducingResumeData: { data in
+                    if let data {
+                        try? data.write(to: resumeURL, options: .atomic)
+                        delegate.persistLinkedMetadata(besideResumeAt: resumeURL)
+                    }
+                })
             }
-            // Move into place atomically; replace any partial leftover.
-            if FileManager.default.fileExists(atPath: destination.path) {
-                try FileManager.default.removeItem(at: destination)
-            }
-            try FileManager.default.moveItem(at: tempURL, to: destination)
         } catch let error as ModelManagerError {
             throw error
         } catch is CancellationError {
@@ -239,26 +461,49 @@ final class ModelManager {
             // can distinguish a user cancel from a real failure.
             throw CancellationError()
         } catch {
-            // URLSession download resumes automatically from partial data on transient failures;
-            // a thrown error here means the download could not complete.
             throw ModelManagerError.downloadFailed(underlying: error)
         }
+
+        // A resumed transfer answers 206, which is inside the success range.
+        if let http = finished.response, !(200...299).contains(http.statusCode) {
+            try? FileManager.default.removeItem(at: finished.fileURL)
+            throw ModelManagerError.serverError(statusCode: http.statusCode)
+        }
+        do {
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try FileManager.default.removeItem(at: destination)
+            }
+            try FileManager.default.moveItem(at: finished.fileURL, to: destination)
+        } catch {
+            try? FileManager.default.removeItem(at: finished.fileURL)
+            throw ModelManagerError.downloadFailed(underlying: error)
+        }
+        // `X-Linked-Etag`/`X-Linked-Size` ride on Hugging Face's `resolve` 302, and a resumed task
+        // continues the CDN URL archived in the blob — so it never sees that hop and reports neither.
+        // Without the carried-over copy a resumed download silently degrades to the GGUF-magic check,
+        // i.e. the tier's whole integrity story would be absent in exactly the flow resume exists for
+        // (the 14 GB transfer that died at 90%), which is also where a short result is most likely.
+        let carried = Self.readLinkedMetadata(besideResumeAt: resumeURL)
+        // Read the carried metadata BEFORE clearing it: completed means there is no partial left.
+        try? FileManager.default.removeItem(at: resumeURL)
+        try? FileManager.default.removeItem(at: Self.linkedMetadataURL(for: resumeURL))
+        return DownloadResult(linkedSHA256: finished.linkedSHA256 ?? carried?.sha256,
+                              linkedSize: finished.linkedSize ?? carried?.size)
     }
 
     // M4 BYOM HF: public surface for an authenticated download. Used by the HF import flow
     // (ModelsPane → HF import sheet). Skips ensureModel's cache reuse path because imported
-    // entries don't share the curated catalog's hash-pinning contract.
+    // entries don't share the curated catalog's hash-pinning contract — but the server-reported
+    // `X-Linked-Etag`/`X-Linked-Size` still verify the bytes, and `lastVerification` reports which.
     @discardableResult
     func downloadAuthenticated(from url: URL, to destination: URL,
                                token: String?) async throws -> URL {
         let auth = (token?.isEmpty == false) ? "Bearer \(token!)" : nil
         try FileManager.default.createDirectory(at: destination.deletingLastPathComponent(),
                                                 withIntermediateDirectories: true)
-        try await download(from: url, to: destination, authorization: auth)
-        guard Self.isValidGGUF(destination) else {
-            try? FileManager.default.removeItem(at: destination)
-            throw ModelManagerError.invalidModelFile(destination.lastPathComponent)
-        }
+        let result = try await download(from: url, to: destination, authorization: auth)
+        lastVerification = try verifyDownloaded(destination, id: destination.lastPathComponent,
+                                                pinnedSHA256: nil, result: result)
         return destination
     }
 
@@ -278,11 +523,44 @@ final class ModelManager {
     }
 }
 
+/// Owns one transfer: progress, the `X-Linked-*` headers, staging the finished file, and persisting
+/// resume data when the transfer dies. State is touched from the URLSession delegate queue and read
+/// from the awaiting task, so every field is behind `lock`.
 private final class DownloadDelegate: NSObject, URLSessionDownloadDelegate {
-    private let onProgress: ((Double?) -> Void)?
+    struct Finished {
+        let fileURL: URL
+        let response: HTTPURLResponse?
+        let linkedSHA256: String?
+        let linkedSize: Int64?
+    }
 
-    init(onProgress: ((Double?) -> Void)?) {
+    private let onProgress: ((Double?) -> Void)?
+    private let stagingURL: URL
+    private let resumeDataURL: URL
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Finished, Error>?
+    private var linkedSHA256: String?
+    private var linkedSize: Int64?
+    private var stagedURL: URL?
+    private var stageError: Error?
+    private var expectedTotalOnResume: Int64 = 0
+
+    init(onProgress: ((Double?) -> Void)?, stagingURL: URL, resumeDataURL: URL) {
         self.onProgress = onProgress
+        self.stagingURL = stagingURL
+        self.resumeDataURL = resumeDataURL
+    }
+
+    /// Attached before `task.resume()`, so no completion can arrive before there is somewhere to send it.
+    func attach(_ continuation: CheckedContinuation<Finished, Error>) {
+        lock.lock(); self.continuation = continuation; lock.unlock()
+    }
+
+    /// Persist whatever `X-Linked-*` this attempt saw, so the NEXT (resumed) attempt can still verify.
+    /// Called from the cancel handler, where the resume blob is being written.
+    func persistLinkedMetadata(besideResumeAt resumeURL: URL) {
+        lock.lock(); let sha = linkedSHA256; let size = linkedSize; lock.unlock()
+        ModelManager.writeLinkedMetadata(.init(sha256: sha, size: size), besideResumeAt: resumeURL)
     }
 
     func urlSession(_ session: URLSession,
@@ -291,16 +569,92 @@ private final class DownloadDelegate: NSObject, URLSessionDownloadDelegate {
                     totalBytesWritten: Int64,
                     totalBytesExpectedToWrite: Int64) {
         guard let onProgress else { return }
-        if totalBytesExpectedToWrite > 0 {
-            onProgress(Double(totalBytesWritten) / Double(totalBytesExpectedToWrite))
+        // A resumed transfer answers 206, whose Content-Length is only the REMAINING range, so
+        // totalBytesExpectedToWrite can be unknown here; didResumeAtOffset gives the real total.
+        lock.lock(); let resumedTotal = expectedTotalOnResume; lock.unlock()
+        let total = totalBytesExpectedToWrite > 0 ? totalBytesExpectedToWrite : resumedTotal
+        if total > 0 {
+            onProgress(Double(totalBytesWritten) / Double(total))
         } else {
             onProgress(nil)
         }
     }
 
-    // Required by the protocol; the async `download(from:)` API consumes the file itself,
-    // so no work is needed here.
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask,
+                    didResumeAtOffset fileOffset: Int64, expectedTotalBytes: Int64) {
+        lock.lock(); expectedTotalOnResume = expectedTotalBytes; lock.unlock()
+    }
+
+    // Hugging Face's `resolve` endpoint answers with a 302 to the CDN and carries the LFS object's
+    // SHA-256/size on THAT response, not on the CDN's final 200 — so capture headers on every hop and
+    // keep the first values we see.
+    func urlSession(_ session: URLSession, task: URLSessionTask,
+                    willPerformHTTPRedirection response: HTTPURLResponse,
+                    newRequest request: URLRequest,
+                    completionHandler: @escaping (URLRequest?) -> Void) {
+        capture(headersFrom: response)
+        completionHandler(request)
+    }
+
     func urlSession(_ session: URLSession,
                     downloadTask: URLSessionDownloadTask,
-                    didFinishDownloadingTo location: URL) {}
+                    didFinishDownloadingTo location: URL) {
+        capture(headersFrom: downloadTask.response as? HTTPURLResponse)
+        // URLSession deletes `location` the moment this returns, so the move MUST happen here,
+        // synchronously — the awaiting caller can never be handed the temp URL.
+        do {
+            try? FileManager.default.removeItem(at: stagingURL)
+            try FileManager.default.moveItem(at: location, to: stagingURL)
+            lock.lock(); stagedURL = stagingURL; lock.unlock()
+        } catch {
+            lock.lock(); stageError = error; lock.unlock()
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        capture(headersFrom: task.response as? HTTPURLResponse)
+        if let error {
+            // The whole point of the delegate-held task: on failure URLSession hands back a blob that
+            // lets the next attempt continue instead of re-pulling gigabytes.
+            if let data = (error as NSError).userInfo[NSURLSessionDownloadTaskResumeData] as? Data {
+                try? data.write(to: resumeDataURL, options: .atomic)
+                // Carry the redirect-only X-Linked-* forward: the resumed attempt continues the CDN URL
+                // archived in the blob and never replays the `resolve` hop that carries them.
+                persistLinkedMetadata(besideResumeAt: resumeDataURL)
+            }
+            finish(.failure(error))
+            return
+        }
+        lock.lock()
+        let staged = stagedURL
+        let stageErr = stageError
+        let sha = linkedSHA256
+        let size = linkedSize
+        lock.unlock()
+        if let stageErr { finish(.failure(stageErr)); return }
+        guard let staged else { finish(.failure(ModelManagerError.noDownloadedFile)); return }
+        finish(.success(Finished(fileURL: staged,
+                                 response: task.response as? HTTPURLResponse,
+                                 linkedSHA256: sha,
+                                 linkedSize: size)))
+    }
+
+    private func capture(headersFrom response: HTTPURLResponse?) {
+        guard let response else { return }
+        lock.lock(); defer { lock.unlock() }
+        if linkedSHA256 == nil {
+            linkedSHA256 = ModelManager.parseLinkedSHA256(response.value(forHTTPHeaderField: "X-Linked-Etag"))
+        }
+        if linkedSize == nil {
+            linkedSize = ModelManager.parseLinkedSize(response.value(forHTTPHeaderField: "X-Linked-Size"))
+        }
+    }
+
+    private func finish(_ result: Result<Finished, Error>) {
+        lock.lock()
+        let cont = continuation
+        continuation = nil          // a continuation must be resumed exactly once
+        lock.unlock()
+        cont?.resume(with: result)
+    }
 }

--- a/Sources/Shadowtype/OnboardingWindow.swift
+++ b/Sources/Shadowtype/OnboardingWindow.swift
@@ -680,6 +680,39 @@ private struct AnyButtonStyle: ButtonStyle {
 
 // MARK: - Step 4: Language model (real ModelManager download)
 
+/// Copy for the model card, kept pure and out of the View so it is unit-testable without a window,
+/// a downloaded file or the network.
+///
+/// Both of these strings used to be constants that lied. The spec line hardcoded "Q4_K_M" for every
+/// row while four Gemma QAT entries are `q4_0`, and the installed status said "Verified · GGUF ✓" for
+/// every download when most catalog entries carry no pinned hash and the only check was the 4-byte
+/// GGUF magic. Each now renders what the specific file actually is / actually got.
+enum ModelCardCopy {
+
+    /// `quant` is `ModelCatalogEntry.quant`; nil (BYOM/imported, whose filename is the user's) renders
+    /// as the neutral "GGUF" rather than inventing a format.
+    static func spec(quant: String?, approxRAMGB: Double) -> String {
+        "\(quant ?? "GGUF") · on-device · ~\(String(format: "%.1f", approxRAMGB)) GB RAM"
+    }
+
+    /// Status line once the model is on disk. `nil` = nothing was downloaded this run (the file was
+    /// already there), so there is no verdict to report — do NOT read that as "unverified".
+    static func installedStatus(_ verification: ModelVerification?) -> String {
+        guard let verification else { return "Installed ✓" }
+        return verification.isHashVerified ? "Verified · SHA-256 ✓" : "Installed · not checksummed"
+    }
+
+    /// Extra line shown only when the bytes could not be hash-checked, so the badge above is never the
+    /// user's only signal. Deliberately plain and undramatic: a missing header is a normal fallback,
+    /// not a compromise. nil when there is nothing to disclose.
+    static func installedNote(_ verification: ModelVerification?) -> String? {
+        guard verification == .unverified else { return nil }
+        return "Hugging Face didn't report a checksum for this file, so we couldn't hash-verify it — "
+            + "we only confirmed it's a well-formed GGUF. The download used HTTPS. Re-downloading from "
+            + "Settings → Models will try again."
+    }
+}
+
 private struct OBModelStep: View {
     /// Mirrors `phase == .installed` up to the root so the footer Continue can gate on it.
     @Binding var installed: Bool
@@ -689,7 +722,8 @@ private struct OBModelStep: View {
     private let manager = ModelManager()
     private let physicalBytes = ProcessInfo.processInfo.physicalMemory
 
-    // The best model that fits this Mac's RAM — the default selection. Every model is free and
+    // The default selection: the best model that both fits this Mac's RAM and stays under
+    // ModelCatalog's first-token-deadline cap — NOT the largest that fits. Every model is free and
     // selectable. Mirrors the Settings → Models recommendation logic.
     private let recommended = ModelCatalog.recommended(
         physicalBytes: ProcessInfo.processInfo.physicalMemory)
@@ -697,6 +731,10 @@ private struct OBModelStep: View {
     @State private var selectedID: String
     @State private var progress: Double = 0     // 0...1
     @State private var phase: Phase = .idle
+    // What actually vouched for the bytes we just downloaded (ModelManager.lastVerification), or nil
+    // when this run downloaded nothing (the file was already on disk). Drives the status line instead
+    // of the old unconditional "Verified · GGUF ✓", which claimed a checksum that mostly never ran.
+    @State private var verification: ModelVerification?
 
     init(installed: Binding<Bool>, onSkip: @escaping () -> Void) {
         _installed = installed
@@ -720,7 +758,13 @@ private struct OBModelStep: View {
             OBHeader(eyebrow: "Language model",
                      title: "Choose your ",
                      accentTail: "on-device model.",
-                     lead: AnyView(Text("Shadowtype runs a local model on Apple Silicon via Metal. We've preselected the best one for your Mac — pick another below if you like. It's stored locally and verified by checksum.")))
+                     // No blanket "verified by checksum" — most catalog entries ship no pinned hash, so
+                     // verification depends on Hugging Face reporting the object's digest and can fall
+                     // back; the status line below reports what actually happened, per download.
+                     // "Fastest good one", not "the best one": the recommendation is capped well below
+                     // what this Mac's RAM allows, because a model that misses the first-token deadline
+                     // shows no suggestion at all.
+                     lead: AnyView(Text("Shadowtype runs a local model on Apple Silicon via Metal. We've preselected the one that gives you the best suggestions while staying fast enough on your Mac — pick another below if you like. It stays on this Mac, and we check the download against the publisher's checksum whenever one is published.")))
                 .padding(.bottom, 24)
 
             // Download card — reflects the currently selected model.
@@ -783,6 +827,11 @@ private struct OBModelStep: View {
                         .font(.system(size: 11.5)).foregroundStyle(OBTheme.textFaint)
                         .fixedSize(horizontal: false, vertical: true)
                         .padding(.top, 8)
+                } else if let note = ModelCardCopy.installedNote(verification) {
+                    Text(note)
+                        .font(.system(size: 11.5)).foregroundStyle(OBTheme.textFaint)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.top, 8)
                 }
             }
             .padding(20)
@@ -831,7 +880,7 @@ private struct OBModelStep: View {
         ModelCatalog.entries.filter { $0.id != selectedID }
     }
     private func spec(_ entry: ModelCatalogEntry) -> String {
-        "Q4_K_M · on-device · ~\(String(format: "%.1f", entry.approxRAMGB)) GB RAM"
+        ModelCardCopy.spec(quant: entry.quant, approxRAMGB: entry.approxRAMGB)
     }
     private var primaryLabel: String {
         switch phase {
@@ -845,7 +894,7 @@ private struct OBModelStep: View {
         switch phase {
         case .idle:        return "Ready to download"
         case .downloading: return String(format: "%.1f GB of %.1f GB", selected.downloadGB * progress, selected.downloadGB)
-        case .installed:   return "Verified · GGUF ✓"
+        case .installed:   return ModelCardCopy.installedStatus(verification)
         case .failed:      return "Download failed — check your connection"
         }
     }
@@ -862,6 +911,9 @@ private struct OBModelStep: View {
         selectedID = entry.id
         progress = isInstalled(entry) ? 1 : 0
         phase = isInstalled(entry) ? .installed : .idle
+        // The previous model's verdict says nothing about this file — clearing it makes the status line
+        // fall back to the plain "Installed ✓" instead of carrying a stale checksum claim across rows.
+        verification = nil
     }
 
     private func startDownload() {
@@ -883,7 +935,9 @@ private struct OBModelStep: View {
         Task {
             do {
                 _ = try await manager.ensureModel(entry)
+                let verdict = manager.lastVerification
                 await MainActor.run {
+                    verification = verdict
                     progress = 1; phase = .installed
                     activate(entry)
                 }

--- a/Sources/Shadowtype/PromptSectionBudget.swift
+++ b/Sources/Shadowtype/PromptSectionBudget.swift
@@ -67,6 +67,34 @@ enum PromptSectionBudget {
     // UTF-8 byte cost of a string (the budget unit).
     static func cost(_ s: String) -> Int { s.utf8.count }
 
+    // Tail window whose START only moves in `anchor`-byte steps — the byte-level twin of the engine's
+    // anchored token trim (InferenceEngine.trimToWindow).
+    //
+    // Why not just keep the last `maxCost` bytes: a plain `.preserveEnd` truncation slides its start
+    // forward by one byte on EVERY keystroke, so the assembled prompt is never a strict extension of the
+    // previous one. The engine's KV reuse is a longest-common-PREFIX match (InferenceEngine.reuseLength),
+    // so a one-byte slide diverges the streams at the first prefix token and forces a full cold re-prefill
+    // of the whole window on every fire — the exact per-keystroke cold-prefill this pass exists to kill,
+    // just relocated from the engine's trim to the allocator's.
+    //
+    // Rounding the DROP up to a multiple of `anchor` pins the window start until the text grows past the
+    // next multiple, so the prompt is byte-stable (a strict extension) for ~`anchor` bytes at a time and
+    // one cold prefill amortizes over hundreds of keystrokes. Costs at most `anchor` bytes of kept context
+    // versus the naive window — cheap next to a re-prefill per keystroke.
+    static func anchoredTail(_ s: String, maxCost: Int, anchor: Int = 512) -> String {
+        let total = cost(s)
+        guard total > maxCost else { return s }
+        guard maxCost > 0 else { return "" }
+        let minDrop = total - maxCost
+        // Rounding up costs at most `step` bytes of kept context, so the step must stay small relative to
+        // the window — a 512-byte step against a 650-byte cap would throw away most of the caret text.
+        let step = max(1, min(anchor, maxCost / 4))
+        // Round the drop UP so the kept window is never larger than maxCost.
+        let drop = ((minDrop + step - 1) / step) * step
+        guard drop < total else { return "" }
+        return truncate(s, toCost: total - drop, end: .preserveEnd)
+    }
+
     // Keep as many whole graphemes from the requested end as fit within `limit` BYTES, so a multi-byte
     // character is never split mid-scalar.
     private static func truncate(_ text: String, toCost limit: Int, end: PromptSection.Truncation) -> String {

--- a/Sources/Shadowtype/PromptSectionBudget.swift
+++ b/Sources/Shadowtype/PromptSectionBudget.swift
@@ -81,18 +81,47 @@ enum PromptSectionBudget {
     // next multiple, so the prompt is byte-stable (a strict extension) for ~`anchor` bytes at a time and
     // one cold prefill amortizes over hundreds of keystrokes. Costs at most `anchor` bytes of kept context
     // versus the naive window — cheap next to a re-prefill per keystroke.
+    // The granularity anchoredTail re-anchors at. Rounding up costs at most one step of kept content, so
+    // the step stays small relative to the window — a 512-byte step against a 650-byte cap would throw
+    // away most of the caret text. Exposed because a caller that budgets OTHER sections around the
+    // windowed content must quantize its reservation to the SAME step, or its own arithmetic reintroduces
+    // the per-keystroke drift this whole mechanism exists to remove (see quantizedReservation).
+    static func anchorStep(maxCost: Int, anchor: Int = 512) -> Int {
+        max(1, min(anchor, maxCost / 4))
+    }
+
+    // How many bytes to set aside for a section of `cost` bytes that is capped at `maxCost`, rounded UP to
+    // the anchor step. anchoredTail pins the kept window's START, but its LENGTH still grows a byte per
+    // keystroke — so a budget computed from the live cost shrinks a byte per keystroke, and any section
+    // allocated from the remainder gets re-cut every fire. When that section sits in FRONT of the caret
+    // text (all of them do), that is a mutating prompt head and a cold re-prefill on every keystroke.
+    // Quantizing holds the reservation still between re-anchors while still shrinking to fit a short
+    // prefix, so the context blocks are not starved when the draft is small.
+    static func quantizedReservation(cost: Int, maxCost: Int, anchor: Int = 512) -> Int {
+        guard maxCost > 0, cost > 0 else { return 0 }
+        let step = anchorStep(maxCost: maxCost, anchor: anchor)
+        return min(maxCost, ((cost + step - 1) / step) * step)
+    }
+
     static func anchoredTail(_ s: String, maxCost: Int, anchor: Int = 512) -> String {
         let total = cost(s)
         guard total > maxCost else { return s }
         guard maxCost > 0 else { return "" }
         let minDrop = total - maxCost
-        // Rounding up costs at most `step` bytes of kept context, so the step must stay small relative to
-        // the window — a 512-byte step against a 650-byte cap would throw away most of the caret text.
-        let step = max(1, min(anchor, maxCost / 4))
+        let step = anchorStep(maxCost: maxCost, anchor: anchor)
         // Round the drop UP so the kept window is never larger than maxCost.
         let drop = ((minDrop + step - 1) / step) * step
         guard drop < total else { return "" }
         return truncate(s, toCost: total - drop, end: .preserveEnd)
+    }
+
+    // Head window: as many whole graphemes from the START as fit in `maxCost` bytes. The mirror of
+    // anchoredTail for content whose USEFUL end is the head — today the post-caret block, where the text
+    // nearest the caret is what the completion must not duplicate and the far end is the droppable part.
+    // Needs no anchoring: unlike the prefix, this content does not grow at the kept end while the user
+    // types, so a fixed-cost head cut is already byte-stable across a burst.
+    static func headWithinCost(_ s: String, maxCost: Int) -> String {
+        truncate(s, toCost: max(0, maxCost), end: .preserveStart)
     }
 
     // Keep as many whole graphemes from the requested end as fit within `limit` BYTES, so a multi-byte

--- a/Sources/Shadowtype/SamplingParams.swift
+++ b/Sources/Shadowtype/SamplingParams.swift
@@ -72,6 +72,32 @@ struct SamplingParams: Sendable, Equatable {
         fim: nil
     )
 
+    // Monotonic counter behind `rewriteDefaults()`. Language mode v5 and bumped only from the rewrite
+    // trigger (main thread), so no lock; a torn increment would at worst repeat one seed, never corrupt.
+    private static var rewriteSeedCounter: UInt32 = 0
+
+    // Sampling for a selection rewrite. Keeps the ghost chain's low temperature + repeat penalty (good
+    // for faithful rewrites) but turns the engine stop policy OFF: a rewrite is a FULL multi-sentence
+    // transformation, and the ghost policy's maxWords cap + first-sentence/newline stop truncated a
+    // multi-sentence selection to just the first ~5 words ("Have you installed the beta"). Bounded
+    // instead by maxTokens + the few-shot block markers (`\nText (` also catches the language-tagged
+    // `Text (in Spanish):` variant).
+    //
+    // A FUNCTION, not a `static let`, because the seed must CHANGE per invocation: ⌘R "redo rewrite"
+    // re-issues the identical selection + action, so the prompt is identical, and the sampler chain
+    // (including `llama_sampler_init_dist(seed)`) is rebuilt inside every generate() call — with the
+    // fixed ghost seed the redo returned byte-identical text, i.e. a silent no-op. `ghostDefaults.seed`
+    // itself stays fixed on purpose: identical prompt → identical ghost is what keeps inline
+    // suggestions stable instead of flickering between keystrokes.
+    static func rewriteDefaults() -> SamplingParams {
+        var p = ghostDefaults
+        p.useEngineStopPolicy = false
+        p.stopStrings = ["\nText:", "\nText (", "\nRewritten:"]
+        rewriteSeedCounter &+= 1
+        p.seed = ghostDefaults.seed &+ rewriteSeedCounter
+        return p
+    }
+
     // OpenAI-ish defaults for API requests: temp 0.7, no top-k (we still apply a high cap to keep
     // candidate scans cheap), no repeat penalty (clients add their own). `apiClamped` overrides
     // these from the request body and re-flags `greedy` when temperature is exactly 0.

--- a/Sources/Shadowtype/ScreenContextProvider.swift
+++ b/Sources/Shadowtype/ScreenContextProvider.swift
@@ -175,11 +175,27 @@ final class ScreenContextProvider {
 
     // MARK: Helpers
 
-    // Keep the most recent text by clamping to the tail (most recently typed/visible context).
+    // Keep the most recent text by clamping to the tail (most recently typed/visible context), CUT ON A
+    // LINE BOUNDARY. A raw character suffix slid by one character per keystroke as the draft grew, so the
+    // kept window — and with it the `Context:` block that sits in FRONT of the prefix — changed
+    // byte-for-byte on every fire. The engine's KV reuse is a longest-common-PREFIX match, so that cost a
+    // full cold re-prefill on every single fire. Dropping whole leading lines instead holds the block's
+    // head still until an entire line falls out of the budget. Only a single line longer than the whole
+    // budget falls back to a character cut (there is no boundary left to cut on).
     static func clamp(_ text: String?, to maxChars: Int) -> String? {
         guard let text, !text.isEmpty, maxChars > 0 else { return nil }
         if text.count <= maxChars { return text }
-        return String(text.suffix(maxChars))
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        var kept: [Substring] = []
+        var total = 0
+        for line in lines.reversed() {
+            let cost = line.count + (kept.isEmpty ? 0 : 1)   // +1 for the newline that rejoins it
+            if total + cost > maxChars { break }
+            total += cost
+            kept.append(line)
+        }
+        guard !kept.isEmpty else { return String(text.suffix(maxChars)) }
+        return kept.reversed().joined(separator: "\n")
     }
 
     // Conservative chrome filter: drop short, punctuation-free lone-token lines — the shape of buttons,
@@ -361,16 +377,27 @@ final class ScreenContextProvider {
 
     // Strip the user's own current draft from the OCR so it isn't duplicated with the prompt prefix.
     // Removes any line equal to, or starting with, the draft's trailing line (the latter also catches a
-    // ghost the OCR captured AFTER the draft, e.g. "Lighter apple pieIngredients…"). No-op for drafts
-    // under 3 chars (too short to match safely). Pure + testable.
-    static func removingDraftEcho(_ text: String?, draft: String) -> String? {
+    // ghost the OCR captured AFTER the draft, e.g. "Lighter apple pieIngredients…") — AND, in the other
+    // direction, a captured line the draft now starts with.
+    //
+    // That reverse case is the one that leaked: the capture is STALE between shots (≤1/s), so the instant
+    // the user types past the captured point the captured line is SHORTER than `tail`,
+    // `t.hasPrefix(tail)` goes false, the line stops being filtered, and the draft echo flows back into
+    // the `Context:` block — the documented doc-echo word-salad, and (since the prompt-head work) a
+    // per-keystroke mutation of the prompt FRONT that also destroys anchored KV reuse. The reverse match
+    // needs its own floor (`minStaleLen`): a short generic captured line ("Hi", "Thanks") is a prefix of
+    // half the drafts on screen and would over-filter genuine context. No-op for drafts under 3 chars
+    // (too short to match safely). Pure + testable.
+    static func removingDraftEcho(_ text: String?, draft: String, minStaleLen: Int = 8) -> String? {
         guard let text else { return nil }
         let tail = (draft.split(whereSeparator: \.isNewline).last.map(String.init) ?? "")
             .trimmingCharacters(in: .whitespaces)
         guard tail.count >= 3 else { return text }
         let kept = text.split(separator: "\n", omittingEmptySubsequences: false).filter { line in
             let t = line.trimmingCharacters(in: .whitespaces)
-            return !(t == tail || t.hasPrefix(tail))
+            if t == tail || t.hasPrefix(tail) { return false }
+            // Stale capture: the line is an earlier, shorter state of the line being typed.
+            return !(t.count >= minStaleLen && tail.hasPrefix(t))
         }
         let out = kept.joined(separator: "\n")
         return out.isEmpty ? nil : out

--- a/Sources/Shadowtype/SentenceBoundary.swift
+++ b/Sources/Shadowtype/SentenceBoundary.swift
@@ -5,6 +5,10 @@
 // (CJK 。！？, Arabic ۔ ؟, Devanagari danda ।॥, Ethiopic ።). No model/format dependency, so the
 // whole policy is unit-tested without loading a model. Consulted by InferenceEngine's ghost decode
 // loop via firstStopIndex(in:before:).
+//
+// It also owns the WORD-boundary half of the same problem — isSpacelessScript — because the ghost
+// decode loop and MidWordHealing both need one answer to "does this script separate words with
+// whitespace?" and that answer belongs next to the terminator table, not duplicated in two files.
 enum SentenceBoundary {
 
     // Terminators that ALWAYS end a sentence — no Latin-period ambiguity. Clause separators
@@ -29,6 +33,38 @@ enum SentenceBoundary {
         "z.b", "d.h", "u.a", "bzw", "ggf", "usw", "ca", "approx", "inc", "ltd", "co",
         "jan", "feb", "mar", "apr", "jun", "jul", "aug", "sept", "sep", "oct", "nov", "dec",
     ]
+
+    // Is `c` written in a script that does NOT separate words with whitespace? Such a character is a
+    // word boundary in its own right.
+    //
+    // Everything downstream of the decode loop used to key off whitespace alone, which made those
+    // languages structurally broken: nothing ever streamed (the whole completion escaped only via the
+    // end-of-run fallback), the word counter never advanced so BOTH maxWords and
+    // stopAtSentenceAfterWords were unreachable, and the completion became one all-or-nothing event
+    // against the 400 ms deadline with no early first-token render. MidWordHealing has the mirror
+    // problem: with no interior spaces the trailing word-char run is the whole clause.
+    //
+    // Scalar ranges rather than a Unicode-script dependency. Hangul is deliberately ABSENT — Korean
+    // does put spaces between words, so the whitespace rule already works there.
+    static func isSpacelessScript(_ c: Character) -> Bool {
+        guard let v = c.unicodeScalars.first?.value else { return false }
+        switch v {
+        case 0x0E00...0x0E7F,     // Thai
+             0x0E80...0x0EFF,     // Lao
+             0x1000...0x109F,     // Myanmar
+             0x1780...0x17FF,     // Khmer
+             0x3040...0x30FF,     // Hiragana + Katakana
+             0x31F0...0x31FF,     // Katakana phonetic extensions
+             0x3400...0x4DBF,     // CJK Unified Ideographs Extension A
+             0x4E00...0x9FFF,     // CJK Unified Ideographs
+             0xF900...0xFAFF,     // CJK Compatibility Ideographs
+             0xFF66...0xFF9D,     // Halfwidth katakana
+             0x20000...0x2FA1F:   // CJK Ext B–F + Compatibility Ideographs Supplement
+            return true
+        default:
+            return false
+        }
+    }
 
     // Does the terminator `c` genuinely end a sentence, given the text immediately before it
     // (`before`, excluding the terminator) and the character right after (nil when not yet decoded —

--- a/Sources/Shadowtype/SettingsWindow.swift
+++ b/Sources/Shadowtype/SettingsWindow.swift
@@ -5,9 +5,12 @@
 //
 // This pane set is a native-SwiftUI recreation of the app/Settings.html design handoff
 // (claude.ai/design). Controls backed by real subsystems are wired live; controls the design
-// shows ahead of their backing (quantization, speculative decoding, all-time/acceptance stats,
-// auto-update channel) persist via @AppStorage and/or render as faithful placeholders so the window
-// matches the mock feature-for-feature.
+// shows ahead of their backing (all-time/acceptance stats, auto-update channel) persist via
+// @AppStorage and/or render as faithful placeholders so the window matches the mock.
+// A "Soon" pill is only honest for something we intend to ship: the mock's Quantization picker and
+// Speculative-decoding (MTP) toggle were removed outright rather than left disabled, because we
+// decided NOT to build them (MTP doubles resident RAM to speed up a 1-4B target that already clears
+// the deadline). Advertising a decided-against feature as "Soon" is a promise we would never keep.
 import Cocoa
 import SwiftUI
 import ApplicationServices
@@ -217,7 +220,7 @@ private struct ProBadge: View {
     var body: some View { EmptyView() }
 }
 
-private enum PillKind { case good, warn, beta, neutral }
+private enum PillKind { case good, warn, neutral }
 
 private struct Pill: View {
     let text: String
@@ -226,7 +229,6 @@ private struct Pill: View {
         switch kind {
         case .good: return .green
         case .warn: return .orange
-        case .beta: return OBTheme.accent
         case .neutral: return .secondary
         }
     }
@@ -464,10 +466,6 @@ private struct ModelsPane: View {
         ModelCatalog.entries[0].id
     // Live: AppDelegate.syncToggles drives the idle-unload timer from this key.
     @AppStorage("shadowtype.unloadIdleMinutes") private var unloadIdle = 10
-    // Not yet wired — these need shipped quantization variants / a speculative drafter, so they stay
-    // disabled so the UI never implies they change runtime behavior.
-    @AppStorage("shadowtype.quantization") private var quantization = "Q4_K_M"
-    @AppStorage("shadowtype.speculativeDecoding") private var speculative = false
 
     @State private var unlocked = Entitlement.isUnlocked
     @State private var installed: Set<String> = []
@@ -530,7 +528,10 @@ private struct ModelsPane: View {
     var body: some View {
         Form {
             Callout(systemImage: "lock.fill",
-                    text: "**All inference runs on this Mac** via llama.cpp + Metal. Models download once over HTTPS, are verified by SHA-256, and never phone home during completion.")
+                    // "when one is available", not a flat "verified by SHA-256": most catalog entries
+                    // ship no pinned hash, so verification depends on Hugging Face returning the LFS
+                    // object's digest — and it can legitimately fall back to the GGUF-magic check.
+                    text: "**All inference runs on this Mac** via llama.cpp + Metal. Models download once over HTTPS, are checked against the publisher's SHA-256 whenever one is available, and never phone home during completion.")
 
             if let err = downloadError {
                 Callout(systemImage: "exclamationmark.triangle.fill",
@@ -572,19 +573,25 @@ private struct ModelsPane: View {
                 caption("Free the model from memory after inactivity; it reloads on your next keystroke.")
             }
 
-            let recommended = ModelCatalog.entries.filter { ModelCatalog.ramOK(for: $0, physicalBytes: physicalBytes) }
+            // "Fits this Mac", NOT "Recommended": ramOK is only a memory gate, and it passes models far
+            // too slow to make the coordinator's first-token deadline (a 32 GB Mac clears the 30B MoE).
+            // ModelCatalog.recommended() is the single recommendation, and it caps well below the RAM
+            // ceiling — labelling this whole list "Recommended" was telling the user to pick the biggest.
+            let fits = ModelCatalog.entries.filter { ModelCatalog.ramOK(for: $0, physicalBytes: physicalBytes) }
             let other = ModelCatalog.entries.filter { !ModelCatalog.ramOK(for: $0, physicalBytes: physicalBytes) }
 
-            if !recommended.isEmpty {
+            if !fits.isEmpty {
                 Section {
-                    ForEach(recommended) { entry in libraryRow(entry) }
+                    ForEach(fits) { entry in libraryRow(entry) }
                 } header: {
                     HStack {
-                        Text("Recommended")
+                        Text("Fits this Mac")
                         Spacer()
                         Text(freeDisk).font(.caption).foregroundStyle(.secondary)
                             .textCase(nil)
                     }
+                } footer: {
+                    Text("Bigger isn't better here: suggestions are dropped when the first token misses its deadline, so the recommended model is the best one that still keeps up. Larger entries are for the local API.")
                 }
             }
 
@@ -594,7 +601,7 @@ private struct ModelsPane: View {
                 } header: {
                     Text("Other models")
                 } footer: {
-                    Text("Larger than ~75% of this Mac's RAM — may run slowly or fail to load.")
+                    Text("Weights plus KV cache don't fit this Mac's memory budget once macOS and the app you're typing into are accounted for — these may swap, run slowly, or fail to load.")
                 }
             }
 
@@ -626,25 +633,6 @@ private struct ModelsPane: View {
                 HStack { Text("Imported"); Spacer() }
             } footer: {
                 Text("Any local .gguf is fair game. We symlink it (your original file isn't copied) and verify the GGUF magic bytes before saving the import.")
-            }
-
-            Section {
-                Picker(selection: $quantization) {
-                    Text("Q4_K_M (recommended)").tag("Q4_K_M")
-                    Text("Q5_K_M (higher quality)").tag("Q5_K_M")
-                    Text("IQ4_XS (smallest)").tag("IQ4_XS")
-                } label: {
-                    HStack(spacing: 6) { Text("Quantization"); SoonPill() }
-                }
-                .disabled(true)
-                Text("Lower bit-width uses less memory; Q4_K_M is the quality/size sweet spot.")
-                    .font(.caption).foregroundStyle(.secondary)
-                Toggle(isOn: $speculative) {
-                    HStack(spacing: 6) { Text("Speculative decoding (MTP)"); Pill(text: "Labs", kind: .beta); SoonPill() }
-                }
-                .disabled(true)
-                Text("Multi-token-prediction drafter. Off by default — can regress on small models.")
-                    .font(.caption).foregroundStyle(.secondary)
             }
         }
         .formStyle(.grouped)
@@ -697,11 +685,18 @@ private struct ModelsPane: View {
         }
     }
 
-    // The catalog entry we auto-select after removing the ACTIVE imported model: the first
-    // recommended (RAM-fitting) entry, falling back to the shipping default.
+    // The catalog entry we auto-select after removing the ACTIVE imported model: the one this Mac is
+    // actually recommended. It used to take the first RAM-fitting entry, which is the SMALLEST that
+    // fits — so removing a BYOM model silently landed the user on the 1B while the rest of the pane
+    // badged something else as recommended. Same call as the badge, so the dialog's named model and
+    // the recommendation cannot disagree.
     private var removalFallbackEntry: ModelCatalogEntry {
-        ModelCatalog.entries.first { ModelCatalog.ramOK(for: $0, physicalBytes: physicalBytes) }
-            ?? ModelCatalog.entries[0]
+        ModelCatalog.recommended(physicalBytes: physicalBytes)
+    }
+
+    // The single entry ModelCatalog.recommended() would pre-select for this Mac, used to badge one row.
+    private var recommendedEntry: ModelCatalogEntry {
+        ModelCatalog.recommended(physicalBytes: physicalBytes)
     }
 
     private func confirmRemove(_ entry: ImportedModelEntry) {
@@ -725,6 +720,10 @@ private struct ModelsPane: View {
                 HStack(spacing: 6) {
                     Text(entry.name).fontWeight(.medium)
                     if isActive { Pill(text: "Active", kind: .good) }
+                    // Marks the ONE entry ModelCatalog.recommended() would pick. The list used to sit
+                    // under a "Recommended" section header covering everything that fit RAM, which
+                    // read as "take the largest" — the opposite of the deadline-capped recommendation.
+                    if entry.id == recommendedEntry.id { Pill(text: "Recommended", kind: .good) }
                     if entry.isInstruct { Pill(text: "Instruct", kind: .warn) }
                 }
                 Text(libraryDetail(entry, ramOK: ramOK))
@@ -1506,7 +1505,6 @@ private struct ShortcutsPane: View {
         .init(action: "Dismiss suggestion", note: "Hide the current ghost text. Typing also dismisses.", keys: ["esc"]),
         .init(action: "Force suggestions here", note: "Turn completions on in the current field, even where Shadowtype stays idle (terminals, code editors).", keys: ["⌃", "`"]),
         .init(action: "Rewrite selection", note: "Rewrite the selected text on-device — improve, shorten, change tone, fix grammar, or summarize. Preview before keeping.", keys: rewriteKeys),
-        .init(action: "Toggle Shadowtype on/off", note: "Global hotkey to pause and resume everywhere.", keys: nil),
         .init(action: "Pause for current app", note: "Temporarily disable in the frontmost app.", keys: ["⌃", "⌥", "P"]),
     ] }
 

--- a/Sources/Shadowtype/SettingsWindow.swift
+++ b/Sources/Shadowtype/SettingsWindow.swift
@@ -904,7 +904,8 @@ private struct ContextPane: View {
     @State private var unlocked = Entitlement.isUnlocked
     @AppStorage("shadowtype.useScreenOCR") private var useScreenOCR = false
     @AppStorage("clipboardContextEnabled") private var clipboardContext = false
-    // Live: AppDelegate.syncToggles caps engine.maxContextTokens from this key.
+    // Live: AppDelegate.syncToggles caps engine.maxContextTokens from this key AND derives the
+    // coordinator's prompt byte budget from it, so this picker sizes the context blocks too.
     @AppStorage("shadowtype.contextWindowTokens") private var contextTokens = 1024
 
     var body: some View {
@@ -925,13 +926,17 @@ private struct ContextPane: View {
                 .disabled(!unlocked)
                 caption("Include recent clipboard text as context when relevant. Nothing is stored; the clipboard is read only while this is on.")
 
+                // 3072 is the top usable step: the engine runs a 4096-token context and reserves 256 for
+                // generation, so anything above ~3840 is silently clamped. Without it the top half of the
+                // window was unreachable from the UI.
                 Picker("Context window size", selection: $contextTokens) {
                     Text("512").tag(512)
                     Text("1024").tag(1024)
                     Text("2048").tag(2048)
+                    Text("3072").tag(3072)
                 }
                 .pickerStyle(.segmented)
-                caption("How much recent text to feed the model. More gives sharper suggestions in long drafts; less is lighter on memory.")
+                caption("How much text to feed the model — the recent text you're typing plus the context sources above. More gives sharper suggestions in long drafts; less is lighter on memory. 3072 is the most the model's window can hold.")
             }
         }
         .formStyle(.grouped)

--- a/Sources/Shadowtype/ShellHistory.swift
+++ b/Sources/Shadowtype/ShellHistory.swift
@@ -10,6 +10,9 @@ enum ShellHistory {
     /// The completion remainder for `currentLine` drawn from the most-recent matching command in
     /// `buffer`, or nil when nothing in history extends the current stem. The returned string is the
     /// part AFTER the typed stem (what Tab would inject), never the whole command.
+    /// CONTRACT: `currentLine` must already be chrome-free (CompletionCoordinator.shellTypedCommand).
+    /// The candidates it is compared against come from shellRecentCommands, which strips the prompt
+    /// sigil — hand it a raw `dario@mac ~/proj % git pu` and nothing can ever match.
     static func prefixMatch(currentLine: String, buffer: String?) -> String? {
         let stem = currentLine
         // Require a real stem so we don't suggest the entire last command on an empty prompt.

--- a/Sources/Shadowtype/StyleProfile.swift
+++ b/Sources/Shadowtype/StyleProfile.swift
@@ -41,12 +41,15 @@ final class StyleProfile {
             self.recentPhrases = recentPhrases
             self.inputCount = inputCount
         }
-        // Tolerant: a pre-bucket file has no inputCount; absent fields decode to empty/zero.
+        // Tolerant: a pre-bucket file has none of these fields; absent tables/lists decode to empty.
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             nGramCounts   = try c.decodeIfPresent([String: Int].self, forKey: .nGramCounts) ?? [:]
             recentPhrases = try c.decodeIfPresent([String].self, forKey: .recentPhrases) ?? []
-            inputCount    = try c.decodeIfPresent(Int.self, forKey: .inputCount) ?? 0
+            // A pre-bucket file has no inputCount, and styleHint() now stays silent below
+            // `minInputsForHint` — decoding that as 0 would mute a long-trained migrated profile forever.
+            // recentPhrases (bounded by maxRecent) is a conservative lower bound on the accepts behind it.
+            inputCount    = try c.decodeIfPresent(Int.self, forKey: .inputCount) ?? recentPhrases.count
         }
     }
 
@@ -92,6 +95,11 @@ final class StyleProfile {
     private let maxNGrams = 400         // distinct 1-/2-word n-grams retained (lowest counts pruned)
     private let maxPhraseWords = 6      // ignore long phrasings as "style" — they're content, not voice
     private let minWordLength = 2       // skip 1-char tokens from the n-gram table (noise)
+
+    // Evidence floor for emitting a hint at all. Under a handful of accepts the table is just whatever the
+    // user happened to type twice, and a wrong hint is not free: it outranks screen context in the prompt
+    // budget, so silence is strictly better than a guess. Internal so tests can train to the boundary.
+    static let minInputsForHint = 8
 
     // Production: per-install secret from the Keychain, store in Application Support next to the other
     // Shadowtype stores.
@@ -157,14 +165,23 @@ final class StyleProfile {
 
     // MARK: - Prompt hint (FR-CTX-3)
 
-    /// A short, prepend-ready style hint built from the user's most representative material — the most
-    /// recent phrasings plus the most frequent multi-word n-grams (which carry phrasing character better
-    /// than single words) — capped to `maxChars`. Returns nil when the profile is empty (so the
-    /// integrator simply prepends nothing). The shape mirrors how OCR context is surfaced: a tagged
-    /// leading line the model can condition on.
+    /// A short, prepend-ready style hint built from the user's most DISTINCTIVE vocabulary — the 1- and
+    /// 2-word n-grams that are not generic function words (which carry phrasing character; see the
+    /// filtering below) — capped to `maxChars`. Returns nil when the profile is empty, when too few
+    /// inputs have been folded in to mean anything (`minInputsForHint`), or when nothing survives
+    /// filtering: an absent hint is always better than a misleading one, and the integrator then simply
+    /// prepends nothing. The shape mirrors how OCR context is surfaced: a tagged leading line the model
+    /// can condition on.
     func styleHint(maxChars: Int) -> String? {
         guard maxChars > 0 else { return nil }
         lock.lock(); defer { lock.unlock() }
+
+        // Evidence gate: a profile folded from three sentences describes nobody, and the hint it produces
+        // still costs prompt budget the real context needs. Say nothing until the user has actually been
+        // observed writing.
+        let totalInputs = record.legacy.inputCount
+            + record.perApp.values.reduce(0) { $0 + $1.inputCount }
+        guard totalInputs >= StyleProfile.minInputsForHint else { return nil }
 
         // Merge every bucket's n-gram counts (legacy + all per-app) into one frequency table — the hint
         // reflects the user's voice across all apps that contributed. Turning collect-inputs off for an
@@ -175,20 +192,35 @@ final class StyleProfile {
         }
         guard !merged.isEmpty else { return nil }
 
-        // Style = register/vocabulary, NOT verbatim content. Emit only the user's most frequent SHORT
-        // n-grams (1- and 2-word). We deliberately DO NOT surface `recentPhrases` (sentence-level content
-        // the base model parrots verbatim across unrelated contexts — a Notes story bleeding into a Slack
-        // message). Also skip any n-gram containing a digit: stray numerals are noise, not style.
-        let isStyleToken: (String) -> Bool = { !$0.contains(where: { $0.isNumber }) }
+        // Style = register/vocabulary, NOT verbatim content. Emit only the user's most representative
+        // SHORT n-grams (1- and 2-word). We deliberately DO NOT surface `recentPhrases` (sentence-level
+        // content the base model parrots verbatim across unrelated contexts — a Notes story bleeding into
+        // a Slack message). Skip any n-gram containing a digit (stray numerals are noise, not style) and
+        // any n-gram made ENTIRELY of generic function words: ranked by raw count those always win over
+        // any real corpus ("of the; in the; to the; and the; the; and; that; with"), and that line of
+        // English glue both evicts the actual context under a tight budget and, sitting immediately
+        // before the `Text:` marker, reads to a base model as document content to imitate.
+        let isStyleToken: (String) -> Bool = {
+            !$0.contains(where: { $0.isNumber }) && StyleProfile.contentTokenCount($0) > 0
+        }
 
-        // Most frequent multi-word n-grams first (carry phrasing register; ties broken alphabetically).
+        // Most DISTINCTIVE multi-word n-grams first: a bigram of two content words ("baile feliz") is
+        // style, one that is half function word ("el baile") barely is, and raw frequency alone orders
+        // them the wrong way round. Count breaks ties, then alphabetically for stability across launches.
         let topBigrams = merged
             .filter { $0.key.contains(" ") && isStyleToken($0.key) }
-            .sorted { $0.value != $1.value ? $0.value > $1.value : $0.key < $1.key }
+            .sorted {
+                let l = StyleProfile.contentTokenCount($0.key)
+                let r = StyleProfile.contentTokenCount($1.key)
+                if l != r { return l > r }
+                return $0.value != $1.value ? $0.value > $1.value : $0.key < $1.key
+            }
             .prefix(8)
             .map { $0.key }
 
-        // Most frequent single words — short, so they keep the hint non-empty under a tight budget.
+        // Most frequent single words — short, so they keep the hint non-empty under a tight budget. Every
+        // survivor of `isStyleToken` is a content word here, so frequency order is already distinctiveness
+        // order.
         let topWords = merged
             .filter { !$0.key.contains(" ") && isStyleToken($0.key) }
             .sorted { $0.value != $1.value ? $0.value > $1.value : $0.key < $1.key }
@@ -273,6 +305,38 @@ final class StyleProfile {
             .sorted { $0.value != $1.value ? $0.value > $1.value : $0.key < $1.key }
             .prefix(max)
         counts = Dictionary(uniqueKeysWithValues: kept.map { ($0.key, $0.value) })
+    }
+
+    // MARK: - Distinctiveness (what makes an n-gram "style" rather than glue)
+
+    // Generic closed-class words — articles, prepositions, conjunctions, pronouns, auxiliaries — in the
+    // two languages this app is written in and used in. These top every frequency table ever built, so
+    // they say nothing about how a PARTICULAR person writes; only content words do. Deliberately no
+    // adverbs/intensifiers ("very", "just"): those genuinely are register. Bounded and hand-written on
+    // purpose — no corpus file, no dependency.
+    private static let functionWords: Set<String> = [
+        // English
+        "a", "am", "an", "and", "any", "are", "as", "at", "be", "been", "being", "but", "by", "can",
+        "could", "did", "do", "does", "for", "from", "had", "has", "have", "he", "her", "him", "his",
+        "how", "i", "if", "in", "into", "is", "it", "its", "me", "might", "more", "most", "must", "my",
+        "no", "not", "of", "on", "or", "our", "out", "over", "she", "shall", "should", "so", "some",
+        "such", "than", "that", "the", "their", "them", "then", "there", "these", "they", "this",
+        "those", "to", "under", "up", "us", "was", "we", "were", "what", "when", "which", "while",
+        "who", "why", "will", "with", "would", "you", "your",
+        // Spanish
+        "al", "algo", "ante", "como", "con", "cual", "cuando", "de", "del", "desde", "donde", "e", "el",
+        "ella", "ellas", "ello", "ellos", "en", "entre", "era", "eran", "es", "esa", "ese", "eso",
+        "esta", "estas", "este", "esto", "estos", "está", "están", "fue", "fueron", "ha", "han", "hasta",
+        "hay", "la", "las", "le", "les", "lo", "los", "mi", "mis", "ni", "nos", "o", "os", "para",
+        "pero", "por", "porque", "que", "qué", "se", "según", "ser", "si", "sí", "sin", "sobre", "su",
+        "sus", "te", "ti", "tu", "tus", "un", "una", "unas", "uno", "unos", "y", "ya", "yo",
+    ]
+
+    // How many of `nGram`'s tokens carry actual voice. 0 means the whole thing is glue ("of the", "the")
+    // and must never reach the hint; higher means more distinctive, which is how the hint is ranked.
+    // Pure + static so the ranking rule is unit-testable without a store, a model, or a prompt.
+    static func contentTokenCount(_ nGram: String) -> Int {
+        nGram.split(separator: " ").reduce(0) { $0 + (functionWords.contains(String($1)) ? 0 : 1) }
     }
 
     // MARK: - Tokenization

--- a/Sources/Shadowtype/TypoGuard.swift
+++ b/Sources/Shadowtype/TypoGuard.swift
@@ -4,13 +4,26 @@
 // answers yes/no. Bias is conservative: false on normal words, proper nouns, short
 // words, numbers, code-ish tokens. A false positive merely skips one suggestion; a
 // false negative just lets a suggestion fire off a misspelling — so we err toward false.
-import Foundation
+//
+// The authority on "is this a real word" is the on-device system dictionary (NSSpellChecker,
+// offline, already linked via AppKit). Everything below only judges words the dictionary REJECTS.
+import AppKit
 
 final class TypoGuard {
     // Tiny built-in lexicon of very common English words. Used only as an edit-distance
-    // anchor: a 4+ letter word that is exactly one edit away from a common word is almost
-    // certainly that word being mistyped (e.g. "teh"->"the", "becuase"->"because").
-    // Kept small on purpose — this is a signal, not a spell-checker.
+    // anchor for words the system dictionary already rejected: a 4+ letter misspelling that is
+    // exactly one edit away from a common word is almost certainly that word being mistyped
+    // ("becuase"->"because", "thier"->"their"). Kept small on purpose — it is a nearness anchor,
+    // NOT a word list: treating "not in this set" as "misspelled" is exactly the bug that made the
+    // guard suppress the ghost on 38/38 ordinary English words (weeks, must, form, hers, ...).
+    //
+    // Note the canonical "teh"->"the" case never reaches here: "teh" is 3 letters and the n >= 4
+    // gate in looksLikeTypo() drops it first. That is deliberate — lowering the gate to 3 floods
+    // false positives across the huge space of valid 3-letter words/abbrevs, and the cost of a
+    // missed flag is only one un-suppressed suggestion. Autocorrect's own floor is 3 (it has a
+    // concrete target to justify the fix), but the coordinator only consults it AFTER looksLikeTypo
+    // has already said yes — so the 3-letter case is reachable in Autocorrect's unit tests, not in
+    // the product.
     private static let common: Set<String> = [
         "the", "and", "that", "have", "for", "not", "with", "you", "this", "but",
         "his", "from", "they", "she", "her", "will", "would", "there", "their",
@@ -46,6 +59,14 @@ final class TypoGuard {
         // never flag (avoids suppressing on legitimate proper nouns). ALL-CAPS acronyms too.
         if isLikelyProperNounOrAcronym(raw) { return false }
 
+        // Real-word gate: if the system dictionary spells this word correctly, it is not a typo —
+        // full stop. This MUST run before every signal below, not just before the edit-distance one:
+        // signal 3 flags real words with long consonant runs ("lengths", "strengths" — 5 consonants)
+        // and signal 2 flags vowel-less real tokens ("brrr", "psst"). We check the word as typed
+        // rather than the lowercased form so correctly-cased tokens the exclusions let through
+        // ("iPhone") are judged as the user wrote them.
+        if TypoGuard.isRealWord(raw) { return false }
+
         // Signal 1: improbable same-letter run (3+ identical letters in a row).
         // e.g. "helllo", "abbbout". Real English maxes at 2 ("ll", "ss").
         if hasRun(chars, ofAtLeast: 3) { return true }
@@ -58,12 +79,67 @@ final class TypoGuard {
         // Signal 3: long consonant cluster (4+ consonants in a row). e.g. "thgnk", "schrt".
         if longestConsonantRun(chars, vowels: vowels) >= 4 { return true }
 
-        // Signal 4: edit-distance == 1 to a common word -> almost certainly that word
-        // being mistyped. The strongest signal; gated to 4+ letters above to avoid noise.
+        // Signal 4: the word is misspelled (the dictionary said so above) AND is exactly one edit
+        // from a common word -> almost certainly that word being mistyped. The nearness requirement
+        // is what keeps us off the names, jargon and foreign words the dictionary simply doesn't
+        // carry: suppressing the ghost on every unknown token would be far too aggressive.
         if isOneEditFromCommon(lower) { return true }
 
         return false
     }
+
+    // MARK: - System dictionary
+
+    /// True when the on-device system dictionary spells `word` correctly in ANY of the languages we
+    /// consult. Shared with Autocorrect so the Free suppressor and the paid corrector apply the exact
+    /// same "is this a real word" test and can never drift apart.
+    ///
+    /// Threading: NSSpellChecker is AppKit and main-thread-affine. Every caller reaches here from
+    /// CompletionCoordinator.fire(), which only ever runs on main — the debounce posts it via
+    /// DispatchQueue.main.asyncAfter, forceActivate() comes off the hotkey/menu handlers, and the
+    /// context re-fire runs inside MainActor.run — so we call the shared checker directly, with no
+    /// hop and no cache. Cost is one word per typing pause: ~0.2ms when a dictionary accepts it (we
+    /// stop at the first hit), ~1.3ms worst case walking the whole list for a genuine typo.
+    static func isRealWord(_ word: String) -> Bool {
+        guard !word.isEmpty else { return false }
+        return spellLanguages.contains { language in
+            // checkSpelling returns the range of the first MISSPELLING; a correctly-spelled word
+            // yields "none found".
+            let miss = NSSpellChecker.shared.checkSpelling(
+                of: word, startingAt: 0, language: language, wrap: false,
+                inSpellDocumentWithTag: 0, wordCount: nil)
+            return miss.location == NSNotFound || miss.length == 0
+        }
+    }
+
+    // The dictionaries isRealWord consults, resolved once on first use (~17ms, on the first typing
+    // pause). We pass EXPLICIT languages instead of letting the checker auto-identify: language ID on
+    // a single word is a coin flip, and falling back to the UI locale would flag every Spanish or
+    // Catalan word as an English typo and kill the ghost for non-English users. Three rules, all
+    // measured on a real machine:
+    //   * English first — the lexicon and the edit-distance signal are English-only, and it is the
+    //     language most tokens are in, so the any-dictionary check usually stops on the first call.
+    //   * Then the user's OWN spelling languages (System Settings > Keyboard > Text Input > Spelling,
+    //     which is what userPreferredLanguages reports), so a Spanish writer's words are real words.
+    //   * DROP any language whose dictionary isn't actually installed. macOS lists those in
+    //     availableLanguages anyway (ca, uk, ko, hi, ar, he, te on the dev box) and they answer "no
+    //     misspelling" for EVERY input — including "thgnk" — so a single one of them in this list
+    //     would silently disable the whole guard. We probe each with a garbage sentinel and keep only
+    //     the dictionaries that reject it.
+    // Catalan ships no macOS dictionary at all, so Catalan words rest on the remaining defences (the
+    // Spanish dictionary accepts many of them, and signal 4 needs nearness to an English word).
+    private static let spellLanguages: [String] = {
+        let checker = NSSpellChecker.shared
+        let available = checker.availableLanguages
+        var candidates = available.filter { $0 == "en" }
+        candidates += checker.userPreferredLanguages.filter {
+            available.contains($0) && !candidates.contains($0)
+        }
+        return candidates.filter { language in
+            checker.checkSpelling(of: "zzqxjvw", startingAt: 0, language: language, wrap: false,
+                                  inSpellDocumentWithTag: 0, wordCount: nil).length > 0
+        }
+    }()
 
     // MARK: - Helpers (pure)
 

--- a/Tests/ShadowtypeTests/AutocorrectTests.swift
+++ b/Tests/ShadowtypeTests/AutocorrectTests.swift
@@ -28,6 +28,17 @@ final class AutocorrectTests: XCTestCase {
         }
     }
 
+    // Regression: the lexicon holds SINGULAR/base forms ("week", "just", "from"), so every regular
+    // plural and dozens of ordinary words had a unique lexicon word exactly one edit away and were
+    // "corrected" into it — weeks->week, must->just, form->from. Rewriting text the user spelled
+    // correctly is worse than any missed fix, so the system dictionary now vetoes first.
+    func testCorrectWordsOutsideLexiconReturnNil() {
+        for w in ["weeks", "must", "form", "years", "days", "teams", "emails", "meetings", "things",
+                  "hers", "code", "three", "whole", "hour", "theme"] {
+            XCTAssertNil(ac.correction(for: w), "correct word rewritten: \(w)")
+        }
+    }
+
     // MARK: - Short tokens return nil
 
     func testShortTokensReturnNil() {

--- a/Tests/ShadowtypeTests/ConfidenceGateTests.swift
+++ b/Tests/ShadowtypeTests/ConfidenceGateTests.swift
@@ -45,6 +45,30 @@ final class ConfidenceGateTests: XCTestCase {
         XCTAssertTrue(gate.meanRejected)
     }
 
+    // With a single sample the geometric mean IS the first token's probability, so letting the mean
+    // reject there would quietly re-decide the first token at the mean's (looser) threshold instead of
+    // the first-token gate's. It only starts speaking from the second token.
+    func testMeanGateStaysSilentUntilASecondToken() {
+        var gate = ConfidenceGate(firstTokenMinProb: 0.05, meanMinProb: 0.03)
+        gate.record(prob: 0.01, isFirst: true)
+        XCTAssertTrue(gate.firstTokenRejected)     // the first-token gate owns this one…
+        XCTAssertFalse(gate.meanRejected)          // …and the mean does not double up on it
+        gate.record(prob: 0.01, isFirst: false)
+        XCTAssertTrue(gate.meanRejected)
+    }
+
+    // The mean is read PER TOKEN so the decode can be cut at the point the model came apart. Read only
+    // after the fact (as it used to be) the sole remaining options are retracting a ghost the user is
+    // already reading, or nothing — and the code refused the retract, so it did nothing.
+    func testRunningMeanTripsMidStreamAfterAConfidentStart() {
+        var gate = ConfidenceGate(firstTokenMinProb: 0.05, meanMinProb: 0.03)
+        gate.record(prob: 0.80, isFirst: true)
+        gate.record(prob: 0.40, isFirst: false)
+        XCTAssertFalse(gate.meanRejected)          // a healthy completion keeps decoding…
+        gate.record(prob: 1e-5, isFirst: false)    // …until it collapses
+        XCTAssertTrue(gate.meanRejected)
+    }
+
     func testOnlyFirstContentTokenSetsFirstProb() {
         var gate = ConfidenceGate(firstTokenMinProb: 0.10, meanMinProb: 0.0)
         gate.record(prob: 0.5, isFirst: true)

--- a/Tests/ShadowtypeTests/CotabbyGrabsTests.swift
+++ b/Tests/ShadowtypeTests/CotabbyGrabsTests.swift
@@ -265,15 +265,62 @@ final class CotabbyGrabsTests: XCTestCase {
         XCTAssertTrue(fits.prompt.contains(screen))
 
         // Prefix takes its 65%, the higher-priority (paid) instruction takes the rest → OCR, lowest
-        // priority, trims to nothing and is dropped.
+        // priority, has nothing left and is dropped. The instruction is sized to exactly the room the
+        // prefix leaves: directive blocks are all-or-nothing now (see assemblePrompt), so handing this
+        // case an oversized one would just drop it and leave the remainder to OCR, testing nothing.
+        let budget = 100
+        let draft = String(repeating: "draft ", count: 200)
+        let keptPrefix = PromptSectionBudget.anchoredTail(
+            CompletionCoordinator.trimmingTrailingInlineWhitespace(draft), maxCost: budget / 100 * 65)
+        let instruction = String(repeating: "i", count: budget - PromptSectionBudget.cost(keptPrefix))
         let starved = CompletionCoordinator.assemblePrompt(
-            prefix: String(repeating: "draft ", count: 200), isLicensed: true,
-            instruction: String(repeating: "instruction ", count: 40), styleHint: nil, styleEnabled: false,
+            prefix: draft, isLicensed: true,
+            instruction: instruction, styleHint: nil, styleEnabled: false,
             clipboard: nil, clipboardEnabled: false, ocr: screen, ocrEnabled: true,
-            totalChars: 100)
+            totalChars: budget)
         XCTAssertFalse(starved.ocrKept)
         XCTAssertFalse(starved.prompt.contains("català"))
-        XCTAssertTrue(starved.prompt.contains("instruction"))   // the paid block still wins over OCR
+        XCTAssertTrue(starved.prompt.contains(instruction))   // the paid block still wins over OCR
+    }
+
+    // The style hint used to fill at priority 60 — above clipboard AND above screen context — so under
+    // budget pressure a vocabulary nudge crowded out the text the next word is actually ABOUT. It is now
+    // the first block dropped.
+    func testStyleHintIsDroppedBeforeScreenContext() {
+        let style = "Writing style: favours words like alpha; beta; gamma"
+        let screen = "the meeting is on Thursday and the venue has changed"
+        let tight = CompletionCoordinator.assemblePrompt(
+            prefix: "so I ", isLicensed: true,
+            instruction: nil, styleHint: style, styleEnabled: true,
+            clipboard: nil, clipboardEnabled: false, ocr: screen, ocrEnabled: true,
+            totalChars: 80)
+        XCTAssertTrue(tight.ocrKept)
+        XCTAssertTrue(tight.prompt.contains(screen))
+        XCTAssertFalse(tight.prompt.contains("alpha"))
+        // Control: with room for both, nothing is dropped and the render order is unchanged.
+        let roomy = CompletionCoordinator.assemblePrompt(
+            prefix: "so I ", isLicensed: true,
+            instruction: nil, styleHint: style, styleEnabled: true,
+            clipboard: nil, clipboardEnabled: false, ocr: screen, ocrEnabled: true,
+            totalChars: 2000)
+        XCTAssertEqual(roomy.prompt, "Context:\n\(style)\n\n\(screen)\n\nText:\nso I")
+    }
+
+    // A directive block's meaning lives in its wording, so the budget must never MUTATE one: trimmed to
+    // its tail, "Always reply in formal Spanish, never use contractions" becomes the different — and
+    // contradictory — instruction "never use contractions". It is taken whole or not at all.
+    func testDirectiveBlockIsDroppedWholeNotTruncated() {
+        // The prefix takes its 65%, leaving less than the instruction's full length. Old behaviour kept
+        // whatever fit from the TAIL — "…ply in formal Spanish, never use contractions".
+        let p = CompletionCoordinator.assemblePrompt(
+            prefix: String(repeating: "Hola ", count: 40), isLicensed: true,
+            instruction: "Always reply in formal Spanish, never use contractions",
+            styleHint: nil, styleEnabled: false,
+            clipboard: nil, clipboardEnabled: false, ocr: nil, ocrEnabled: false,
+            totalChars: 100)
+        XCTAssertFalse(p.prompt.contains("never use contractions"))  // no mutated instruction…
+        XCTAssertFalse(p.prompt.contains("Context:"))                // …the block is gone entirely
+        XCTAssertTrue(p.prompt.hasSuffix("Hola"))                    // bare prefix
     }
 
     // The prompt budget is derived from the engine's live token cap instead of a hardcoded 6000 that

--- a/Tests/ShadowtypeTests/CotabbyGrabsTests.swift
+++ b/Tests/ShadowtypeTests/CotabbyGrabsTests.swift
@@ -270,9 +270,16 @@ final class CotabbyGrabsTests: XCTestCase {
         // case an oversized one would just drop it and leave the remainder to OCR, testing nothing.
         let budget = 100
         let draft = String(repeating: "draft ", count: 200)
+        // Sized against the QUANTIZED reservation, not the prefix's raw cost: the context blocks are
+        // budgeted from `totalChars - quantizedReservation(...)` so their bytes don't drift a byte per
+        // keystroke (see assemblePrompt). Re-deriving it here keeps this case exactly-sized instead of
+        // one byte over, which would drop the atomic instruction and test the opposite of the intent.
+        let prefixCap = budget / 100 * 65
         let keptPrefix = PromptSectionBudget.anchoredTail(
-            CompletionCoordinator.trimmingTrailingInlineWhitespace(draft), maxCost: budget / 100 * 65)
-        let instruction = String(repeating: "i", count: budget - PromptSectionBudget.cost(keptPrefix))
+            CompletionCoordinator.trimmingTrailingInlineWhitespace(draft), maxCost: prefixCap)
+        let reserve = PromptSectionBudget.quantizedReservation(
+            cost: PromptSectionBudget.cost(keptPrefix), maxCost: prefixCap)
+        let instruction = String(repeating: "i", count: budget - reserve)
         let starved = CompletionCoordinator.assemblePrompt(
             prefix: draft, isLicensed: true,
             instruction: instruction, styleHint: nil, styleEnabled: false,

--- a/Tests/ShadowtypeTests/CotabbyGrabsTests.swift
+++ b/Tests/ShadowtypeTests/CotabbyGrabsTests.swift
@@ -159,6 +159,35 @@ final class CotabbyGrabsTests: XCTestCase {
         XCTAssertEqual(out.map(\.content), ["AAAA", "BBBB"])   // unbounded → nothing trimmed
     }
 
+    // The property the anchored window exists for: while the user types, the KEPT WINDOW'S HEAD must hold
+    // still, so each assembled prompt is a strict extension of the last one and the engine's
+    // longest-common-prefix KV reuse survives. A plain `.preserveEnd` cut slides one byte per keystroke and
+    // diverges at the first token, forcing a cold re-prefill on every fire.
+    func testAnchoredTailHeadIsStableAcrossKeystrokes() {
+        let maxCost = 1000, anchor = 512
+        var heads = Set<String>()
+        // Simulate 200 consecutive keystrokes on a draft already past the budget.
+        for n in 1500...1700 {
+            let draft = String(repeating: "x", count: n - 20) + String(repeating: "y", count: 20)
+            let win = PromptSectionBudget.anchoredTail(draft, maxCost: maxCost, anchor: anchor)
+            XCTAssertLessThanOrEqual(PromptSectionBudget.cost(win), maxCost)   // never exceeds the cap
+            XCTAssertTrue(draft.hasSuffix(win))                                // always the caret-side tail
+            heads.insert(String(win.prefix(24)))
+        }
+        // 201 keystrokes spanning 200 bytes of growth: an unanchored window would produce ~201 distinct
+        // heads (one re-prefill each). Anchored to 512, it re-anchors at most once.
+        XCTAssertLessThanOrEqual(heads.count, 2, "window head slid \(heads.count) times; anchoring is broken")
+    }
+
+    func testAnchoredTailIsLosslessUnderBudgetAndNeverExceedsCap() {
+        XCTAssertEqual(PromptSectionBudget.anchoredTail("hello", maxCost: 1000), "hello")   // fits → untouched
+        // Rounding the drop UP keeps the window at or below the cap, never above it.
+        for n in 900...1100 {
+            let s = String(repeating: "z", count: n)
+            XCTAssertLessThanOrEqual(PromptSectionBudget.cost(PromptSectionBudget.anchoredTail(s, maxCost: 1000, anchor: 64)), 1000)
+        }
+    }
+
     func testBudgetTruncationEnds() {
         let preserveEnd = [PromptSection(name: "x", content: "abcdef", priority: 1, minChars: 0, maxChars: 6, truncation: .preserveEnd)]
         XCTAssertEqual(PromptSectionBudget.allocate(preserveEnd, totalChars: 3).first?.content, "def")
@@ -183,7 +212,7 @@ final class CotabbyGrabsTests: XCTestCase {
             prefix: "the quick brown", isLicensed: true,
             instruction: "be terse", styleHint: nil, styleEnabled: false,
             clipboard: nil, clipboardEnabled: false, ocr: nil, ocrEnabled: false)
-        XCTAssertEqual(p, "Context:\nbe terse\n\nText:\nthe quick brown")
+        XCTAssertEqual(p.prompt, "Context:\nbe terse\n\nText:\nthe quick brown")
     }
 
     func testAssemblePromptBudgetProtectsPrefix() {
@@ -193,8 +222,76 @@ final class CotabbyGrabsTests: XCTestCase {
             instruction: nil, styleHint: nil, styleEnabled: false,
             clipboard: nil, clipboardEnabled: false, ocr: bigOCR, ocrEnabled: true,
             totalChars: 200)
-        XCTAssertTrue(p.hasSuffix("Text:\nmy real sentence so far"))   // caret text never starved
-        XCTAssertLessThanOrEqual(p.count, 260)                         // budget + framing overhead
+        XCTAssertTrue(p.prompt.hasSuffix("Text:\nmy real sentence so far"))  // caret text never starved
+        XCTAssertLessThanOrEqual(p.prompt.count, 260)                        // budget + framing overhead
+    }
+
+    // The other half of "never starved": the prefix must not starve the CONTEXT either. It used to
+    // declare its own full length as maxChars, so any draft longer than the budget took 100% of it and
+    // every context block trimmed to "" — instruction/style/clipboard/OCR silently vanished in long
+    // documents and the caller got the bare prefix (the flat-document shape that yields word-salad).
+    func testAssemblePromptKeepsContextWhenPrefixOverflowsBudget() {
+        let budget = 1000
+        let bigPrefix = String(repeating: "a ", count: 5000)   // 10 000 bytes of draft — 10× the budget
+        let p = CompletionCoordinator.assemblePrompt(
+            prefix: bigPrefix, isLicensed: true,
+            instruction: "reply in a friendly tone", styleHint: nil, styleEnabled: false,
+            clipboard: nil, clipboardEnabled: false, ocr: nil, ocrEnabled: false,
+            totalChars: budget)
+        XCTAssertTrue(p.prompt.hasPrefix("Context:\n"))                 // framing survives…
+        XCTAssertTrue(p.prompt.contains("reply in a friendly tone"))    // …and so does the instruction
+        // The prefix is capped at 65% of the budget: still dominant, no longer unbounded. Asserted as a
+        // RANGE, not an exact 650: the window is anchor-quantized (PromptSectionBudget.anchoredTail) so its
+        // head holds still while typing, which costs up to one step of kept bytes. The bounds still fail if
+        // the cap is removed (unbounded → 10 000) or if the prefix collapses.
+        let keptPrefix = p.prompt.components(separatedBy: "\n\nText:\n").last ?? ""
+        XCTAssertLessThanOrEqual(PromptSectionBudget.cost(keptPrefix), 650)
+        XCTAssertGreaterThan(PromptSectionBudget.cost(keptPrefix), 650 - 650 / 4)
+        // Whole prompt stays inside the budget plus the framing the sections aren't charged for.
+        XCTAssertLessThanOrEqual(PromptSectionBudget.cost(p.prompt), budget + 64)
+    }
+
+    // assemblePrompt reports whether the OCR block SURVIVED, because CompletionCoordinator arms the
+    // render-time context-language suppression off that fact: hiding a ghost for "drifting" from screen
+    // context that the budget dropped means suppressing on evidence the model was never given.
+    func testAssemblePromptReportsWhetherOCRSurvivedTheBudget() {
+        let screen = "Aquesta és una conversa en català sobre la feina."
+        let fits = CompletionCoordinator.assemblePrompt(
+            prefix: "També necesito ", isLicensed: false,
+            instruction: nil, styleHint: nil, styleEnabled: false,
+            clipboard: nil, clipboardEnabled: false, ocr: screen, ocrEnabled: true,
+            totalChars: 2000)
+        XCTAssertTrue(fits.ocrKept)
+        XCTAssertTrue(fits.prompt.contains(screen))
+
+        // Prefix takes its 65%, the higher-priority (paid) instruction takes the rest → OCR, lowest
+        // priority, trims to nothing and is dropped.
+        let starved = CompletionCoordinator.assemblePrompt(
+            prefix: String(repeating: "draft ", count: 200), isLicensed: true,
+            instruction: String(repeating: "instruction ", count: 40), styleHint: nil, styleEnabled: false,
+            clipboard: nil, clipboardEnabled: false, ocr: screen, ocrEnabled: true,
+            totalChars: 100)
+        XCTAssertFalse(starved.ocrKept)
+        XCTAssertFalse(starved.prompt.contains("català"))
+        XCTAssertTrue(starved.prompt.contains("instruction"))   // the paid block still wins over OCR
+    }
+
+    // The prompt budget is derived from the engine's live token cap instead of a hardcoded 6000 that
+    // assumed a 4096-token window: the default window is 1024 tokens, so a 6000-byte prompt was
+    // front-trimmed by InferenceEngine.generate() — and the front is the `Context:` header plus every
+    // context block. Must stay under ~4 bytes/token (English prose) at every picker step.
+    func testPromptBudgetFitsInsideTheEngineTokenCap() {
+        for tokens in [512, 1024, 2048, 3072] {   // the Settings → Context picker steps
+            let budget = CompletionCoordinator.promptBudgetBytes(forContextTokens: tokens)
+            XCTAssertLessThan(budget, tokens * 4, "budget must under-fill the window at \(tokens)")
+            XCTAssertGreaterThan(budget, tokens, "budget shouldn't be needlessly tiny at \(tokens)")
+        }
+        // Strictly monotone in the setting, and the old hardcoded 6000 is now out of reach at the default.
+        XCTAssertLessThan(CompletionCoordinator.promptBudgetBytes(forContextTokens: 1024), 6000)
+        XCTAssertGreaterThan(CompletionCoordinator.promptBudgetBytes(forContextTokens: 3072),
+                             CompletionCoordinator.promptBudgetBytes(forContextTokens: 2048))
+        // A degenerate/absent setting can never yield a zero or negative budget.
+        XCTAssertGreaterThanOrEqual(CompletionCoordinator.promptBudgetBytes(forContextTokens: 0), 256)
     }
 
     // MARK: - OverlayRenderer pure geometry/colors (RTL clamp + appearance-adaptive palette)
@@ -301,6 +398,8 @@ final class CotabbyGrabsTests: XCTestCase {
         func load(modelPath: String) throws { loadCalled = true; isLoaded = true }
         func unload() { isLoaded = false }
         func requestCancel() {}
+        private(set) var releasedSeqs: [Int32] = []
+        func releaseSeq(_ seqID: Int32) { releasedSeqs.append(seqID) }
         func generate(prompt: String, maxTokens: Int,
                       seqID: Int32, params: SamplingParams,
                       requiredPrefix: [UInt8]?,

--- a/Tests/ShadowtypeTests/EngineTrimTests.swift
+++ b/Tests/ShadowtypeTests/EngineTrimTests.swift
@@ -1,5 +1,6 @@
-// Pure unit tests for the over-cap prompt trim (InferenceEngine.trimToWindow) and its interaction
-// with the KV-reuse decision (InferenceEngine.reuseLength). Both are static and model-free.
+// Pure unit tests for the prompt-token budget (InferenceEngine.generationReserve / promptCap), the
+// over-cap prompt trim (InferenceEngine.trimToWindow) and its interaction with the KV-reuse decision
+// (InferenceEngine.reuseLength). All static and model-free.
 //
 // The two bugs these pin down:
 //  1. the old `tokens.suffix(cap)` dropped the BOS that tokenize(addSpecial: true) prepends —
@@ -14,6 +15,49 @@ final class EngineTrimTests: XCTestCase {
     // A synthetic prompt: BOS at slot 0, then `body` distinct tokens (1, 2, 3, ...).
     private func prompt(bodyCount: Int, bos: Int32 = 2) -> [Int32] {
         [bos] + (1...bodyCount).map { Int32($0) }
+    }
+
+    // MARK: - Generation reserve / prompt cap
+
+    // The bug: the reserve was a flat 256 while /v1 admits max_tokens up to 2048, so a prompt trimmed
+    // to the cap plus its own generated tokens overran the 4096 KV pool and llama_decode failed
+    // mid-stream (HTTP 500). The cap must leave room for the tokens the call will actually produce.
+    func testPromptCapLeavesRoomForRequestedGeneration() {
+        let nCtx = 4096
+        for maxTokens in [1, 16, 24, 256, 512, 1024, 2048] {
+            let cap = InferenceEngine.promptCap(nCtx: nCtx, maxTokens: maxTokens, maxContextTokens: 4096)
+            XCTAssertLessThanOrEqual(cap + maxTokens, nCtx,
+                                     "prompt cap + max_tokens overruns n_ctx at maxTokens=\(maxTokens)")
+        }
+    }
+
+    func testGhostBudgetIsUnchangedByTheReserveFix() {
+        // Ghost generates ~16-24 tokens, so the 256 floor still binds and the shipping cap stays 3840
+        // — the anchored-trim tests above are written against that number.
+        XCTAssertEqual(InferenceEngine.generationReserve(maxTokens: 24), 256)
+        XCTAssertEqual(InferenceEngine.promptCap(nCtx: 4096, maxTokens: 24, maxContextTokens: 4096), 3840)
+    }
+
+    func testUserContextWindowStillBinds() {
+        // "Context window size" below the derived cap wins — a deliberate user choice, not a failure.
+        XCTAssertEqual(InferenceEngine.promptCap(nCtx: 4096, maxTokens: 16, maxContextTokens: 512), 512)
+    }
+
+    func testMaxTokensCeilingStillLeavesAUsableWindow() {
+        // The routes clamp max_tokens to 2048. At that ceiling the remaining window must stay above
+        // minPromptWindow, or every long-prompt request would be refused outright.
+        XCTAssertGreaterThanOrEqual(4096 - InferenceEngine.generationReserve(maxTokens: 2048),
+                                    InferenceEngine.minPromptWindow)
+        // Past the ceiling the window IS exhausted — that's the case generate() refuses instead of
+        // front-trimming the prompt to a stub.
+        XCTAssertLessThan(4096 - InferenceEngine.generationReserve(maxTokens: 4000),
+                          InferenceEngine.minPromptWindow)
+    }
+
+    func testPromptCapNeverGoesNegative() {
+        // An absurd max_tokens must not produce a negative cap that the trim would then misuse.
+        XCTAssertGreaterThanOrEqual(
+            InferenceEngine.promptCap(nCtx: 4096, maxTokens: 100_000, maxContextTokens: 4096), 8)
     }
 
     // MARK: - Under the cap: untouched

--- a/Tests/ShadowtypeTests/EngineTrimTests.swift
+++ b/Tests/ShadowtypeTests/EngineTrimTests.swift
@@ -1,0 +1,120 @@
+// Pure unit tests for the over-cap prompt trim (InferenceEngine.trimToWindow) and its interaction
+// with the KV-reuse decision (InferenceEngine.reuseLength). Both are static and model-free.
+//
+// The two bugs these pin down:
+//  1. the old `tokens.suffix(cap)` dropped the BOS that tokenize(addSpecial: true) prepends —
+//     Gemma-3, the shipping default model, is trained with a mandatory BOS;
+//  2. that same suffix slid the window one token per keystroke, so the prompt head changed on every
+//     fire, reuseLength() returned 0 and every keystroke in a long document paid a cold prefill.
+import XCTest
+@testable import Shadowtype
+
+final class EngineTrimTests: XCTestCase {
+
+    // A synthetic prompt: BOS at slot 0, then `body` distinct tokens (1, 2, 3, ...).
+    private func prompt(bodyCount: Int, bos: Int32 = 2) -> [Int32] {
+        [bos] + (1...bodyCount).map { Int32($0) }
+    }
+
+    // MARK: - Under the cap: untouched
+
+    func testNoTrimWhenWithinCap() {
+        let toks = prompt(bodyCount: 99)   // 100 tokens
+        XCTAssertEqual(InferenceEngine.trimToWindow(toks, cap: 100, keepFirst: true), toks)
+        XCTAssertEqual(InferenceEngine.trimToWindow(toks, cap: 4096, keepFirst: true), toks)
+    }
+
+    // MARK: - BOS preservation (FIX 3)
+
+    func testTrimKeepsBOSAtSlotZero() {
+        let toks = prompt(bodyCount: 4999)   // 5000 tokens, BOS = 2
+        let out = InferenceEngine.trimToWindow(toks, cap: 3840, keepFirst: true)
+        XCTAssertEqual(out.first, 2, "BOS must survive the front-trim")
+        // Slot 1 onwards is a contiguous tail of the original body — the trim only drops from the
+        // front, it never reorders or gaps the kept context.
+        let tail = Array(out.dropFirst())
+        XCTAssertEqual(tail, Array(toks.suffix(tail.count)))
+    }
+
+    func testTrimWithoutBOSIsAPlainTail() {
+        // A vocab that prepends no BOS gets the pre-fix behaviour: a pure suffix (still anchored).
+        let toks = (1...5000).map { Int32($0) }
+        let out = InferenceEngine.trimToWindow(toks, cap: 3840, keepFirst: false)
+        XCTAssertEqual(out, Array(toks.suffix(out.count)))
+        XCTAssertLessThanOrEqual(out.count, 3840)
+    }
+
+    // MARK: - Cap is never exceeded (the anchor rounds the DROP up, not down)
+
+    func testResultNeverExceedsCap() {
+        // Sweep the boundary region: the anchor must never keep MORE than `cap` tokens, or the
+        // n_ctx head-room the cap protects (genReserve) is gone and llama_decode fails mid-stream.
+        for count in 3800...4200 {
+            let toks = prompt(bodyCount: count - 1)
+            let out = InferenceEngine.trimToWindow(toks, cap: 3840, keepFirst: true)
+            XCTAssertLessThanOrEqual(out.count, 3840, "cap blown at count=\(count)")
+        }
+    }
+
+    func testTinyCapStillProducesAValidWindow() {
+        // Degenerate cap (nCtx - genReserve floor). The anchor scales down instead of eating the
+        // whole window, and the result still fits and still starts with BOS.
+        let toks = prompt(bodyCount: 199)
+        let out = InferenceEngine.trimToWindow(toks, cap: 8, keepFirst: true)
+        XCTAssertLessThanOrEqual(out.count, 8)
+        XCTAssertGreaterThan(out.count, 1)
+        XCTAssertEqual(out.first, 2)
+    }
+
+    // MARK: - Anchoring (FIX 4): the head is byte-stable between re-anchors
+
+    func testHeadIsStableAcrossKeystrokes() {
+        // Simulate typing: the prompt grows one token at a time past the cap. Within one anchor
+        // step the trimmed head must be IDENTICAL, otherwise reuseLength collapses.
+        let cap = 3840
+        let anchor = InferenceEngine.trimAnchor
+        let startCount = 4001                                   // prompt(bodyCount: 4000).count
+        // Tokens that can still be typed before the drop count crosses the next multiple of `anchor`.
+        let room = anchor - ((startCount - cap) % anchor)
+        let base = InferenceEngine.trimToWindow(prompt(bodyCount: 4000), cap: cap, keepFirst: true)
+        for extra in 1...room {
+            let out = InferenceEngine.trimToWindow(prompt(bodyCount: 4000 + extra), cap: cap, keepFirst: true)
+            XCTAssertEqual(Array(out.prefix(8)), Array(base.prefix(8)),
+                           "head moved after \(extra) more tokens — the window is sliding again")
+        }
+    }
+
+    func testReuseSurvivesTypingAndOnlyResetsAtTheReAnchor() {
+        // The real regression: cached vs. next-keystroke prompt. With a sliding window reuse was 0 on
+        // every fire (cold prefill per keystroke); anchored, the whole cached prefix is reused until
+        // the window re-anchors.
+        let cap = 3840
+        let cached = InferenceEngine.trimToWindow(prompt(bodyCount: 4000), cap: cap, keepFirst: true)
+        let next = InferenceEngine.trimToWindow(prompt(bodyCount: 4001), cap: cap, keepFirst: true)
+        XCTAssertEqual(InferenceEngine.reuseLength(cached: cached, new: next), cached.count,
+                       "one more typed token must reuse the entire cached prefix")
+
+        // Walk a full anchor step forward: exactly ONE fire loses the cached prefix in that whole
+        // span, instead of one per keystroke. (At the re-anchor reuse drops to 1, not 0 — the BOS
+        // still matches — which is a seq_rm above slot 0, i.e. a cold prefill in all but name.)
+        var reAnchors = 0
+        var prev = cached
+        for extra in 1...(InferenceEngine.trimAnchor + 1) {
+            let cur = InferenceEngine.trimToWindow(prompt(bodyCount: 4000 + extra), cap: cap, keepFirst: true)
+            if InferenceEngine.reuseLength(cached: prev, new: cur) < prev.count { reAnchors += 1 }
+            prev = cur
+        }
+        XCTAssertEqual(reAnchors, 1,
+                       "expected exactly one re-anchor per \(InferenceEngine.trimAnchor) tokens typed")
+    }
+
+    func testUnanchoredSuffixWouldHaveResetEveryKeystroke() {
+        // Control case documenting the bug: the old `suffix(cap)` shifts the head every keystroke,
+        // so reuseLength is 0 every time. This is what the anchor buys us over.
+        let cap = 3840
+        let a = Array(prompt(bodyCount: 4000).suffix(cap))
+        let b = Array(prompt(bodyCount: 4001).suffix(cap))
+        XCTAssertEqual(InferenceEngine.reuseLength(cached: a, new: b), 0)
+        XCTAssertNotEqual(a.first, 2, "and the old path dropped BOS too")
+    }
+}

--- a/Tests/ShadowtypeTests/HFResolverTests.swift
+++ b/Tests/ShadowtypeTests/HFResolverTests.swift
@@ -166,4 +166,87 @@ extension HFResolverTests {
         XCTAssertEqual(HFResolver.preferredImportFile(in: list)?.filename, "model.Q2_K.gguf")
         XCTAssertNil(HFResolver.preferredImportFile(in: []))
     }
+
+    func testPreferredImportFilePrefersIMatrixQ4KM() {
+        // Same size and speed as the plain quant, lower perplexity on rare/non-English tokens — so
+        // when a repo ships both, the imatrix build is the better default.
+        let list = [sib("model.Q4_K_M.gguf", 2), sib("model.i1-Q4_K_M.gguf", 2)]
+        XCTAssertEqual(HFResolver.preferredImportFile(in: list)?.filename, "model.i1-Q4_K_M.gguf")
+        // Reverse order must give the same answer (it's a preference, not "first wins").
+        let reversed = [sib("model.i1-Q4_K_M.gguf", 2), sib("model.Q4_K_M.gguf", 2)]
+        XCTAssertEqual(HFResolver.preferredImportFile(in: reversed)?.filename, "model.i1-Q4_K_M.gguf")
+    }
+
+    func testPreferredImportFileNeverPreSelectsAShard() {
+        // The 70B case: the only Q4_K_M in the repo is split, so it must not be the default pick.
+        let list = [sib("model-Q4_K_M-00001-of-00002.gguf", 9),
+                    sib("model-Q4_K_M-00002-of-00002.gguf", 9),
+                    sib("model.Q2_K.gguf", 1)]
+        XCTAssertEqual(HFResolver.preferredImportFile(in: list)?.filename, "model.Q2_K.gguf")
+        // All-shards list: nothing is safely importable.
+        XCTAssertNil(HFResolver.preferredImportFile(in: [sib("m-00001-of-00003.gguf", 1)]))
+    }
+
+    func testIsIMatrixBuildMatchesWholeTokensOnly() {
+        XCTAssertTrue(HFResolver.isIMatrixBuild("Qwen3-8B.i1-Q4_K_M.gguf"))
+        XCTAssertTrue(HFResolver.isIMatrixBuild("model-Q4_K_M-imat.gguf"))
+        XCTAssertTrue(HFResolver.isIMatrixBuild("model.imatrix.Q4_K_M.gguf"))
+        XCTAssertFalse(HFResolver.isIMatrixBuild("model.Q4_K_M.gguf"))
+        // "gemini1-" contains the substring "i1-" but is not an imatrix build.
+        XCTAssertFalse(HFResolver.isIMatrixBuild("gemini1-Q4_K_M.gguf"))
+    }
+}
+
+// MARK: - Sharded (split) GGUF rejection
+
+extension HFResolverTests {
+
+    func testShardInfoDetectsSplitFiles() {
+        XCTAssertEqual(HFResolver.shardInfo("model-Q4_K_M-00001-of-00002.gguf")?.index, 1)
+        XCTAssertEqual(HFResolver.shardInfo("model-Q4_K_M-00001-of-00002.gguf")?.total, 2)
+        XCTAssertEqual(HFResolver.shardInfo("Big-Model-00003-of-00017.GGUF")?.index, 3)
+        XCTAssertEqual(HFResolver.shardInfo("sub/dir/m-00002-of-00002.gguf")?.index, 2)
+    }
+
+    func testShardInfoIgnoresWholeFiles() {
+        XCTAssertNil(HFResolver.shardInfo("model.Q4_K_M.gguf"))
+        XCTAssertNil(HFResolver.shardInfo("model-00001-of-00001.gguf"),
+                     "-00001-of-00001 IS the whole model; rejecting it would block a valid import")
+        XCTAssertNil(HFResolver.shardInfo("model-1-of-2.gguf"), "only the 5-digit convention counts")
+        XCTAssertNil(HFResolver.shardInfo("model-00003-of-00002.gguf"), "index past total is not a shard")
+        XCTAssertNil(HFResolver.shardInfo("model-00001-of-00002.bin"))
+    }
+
+    func testPartitionShardsSplitsTheList() {
+        let list = [sib("whole.Q4_K_M.gguf", 1),
+                    sib("big-00001-of-00002.gguf", 9), sib("big-00002-of-00002.gguf", 9)]
+        let p = HFResolver.partitionShards(list)
+        XCTAssertEqual(p.whole.map(\.filename), ["whole.Q4_K_M.gguf"])
+        XCTAssertEqual(p.shards.count, 2)
+    }
+
+    func testShardRejectionMessageNamesTheOffendingFile() {
+        let msg = HFResolver.shardRejectionMessage([sib("big-00001-of-00002.gguf", 9)])
+        XCTAssertTrue(msg.contains("big-00001-of-00002.gguf"), msg)
+        XCTAssertTrue(msg.lowercased().contains("split"), "must say WHY it was rejected: \(msg)")
+    }
+
+    func testDirectShardURLRejectedWithReason() {
+        // Every shard carries the GGUF magic, so this used to download + register fine and then die at
+        // load with the generic "may be corrupt or unsupported".
+        let p = HFResolver.parse(
+            "https://huggingface.co/o/r/resolve/main/Model-Q4_K_M-00001-of-00002.gguf")
+        guard case let .invalid(reason) = p else {
+            XCTFail("a shard URL must be rejected, got \(p)"); return
+        }
+        XCTAssertTrue(reason.contains("split"), "reason must explain the shard problem: \(reason)")
+    }
+
+    func testDirectWholeFileURLStillAccepted() {
+        let p = HFResolver.parse("https://huggingface.co/o/r/resolve/main/Model-00001-of-00001.gguf")
+        guard case let .directFile(_, _, _, filename, _) = p else {
+            XCTFail("a single-part file must still import, got \(p)"); return
+        }
+        XCTAssertEqual(filename, "Model-00001-of-00001.gguf")
+    }
 }

--- a/Tests/ShadowtypeTests/MidWordHealingTests.swift
+++ b/Tests/ShadowtypeTests/MidWordHealingTests.swift
@@ -24,10 +24,40 @@ final class MidWordHealingTests: XCTestCase {
         XCTAssertNil(MidWordHealing.split(prefix: String(repeating: "a", count: 25), maxStem: 24))
     }
 
-    func testSplitHandlesNonLatinStem() {
-        // CJK has no spaces, but the head/stem split still works on the trailing run.
+    func testSplitCapsSpacelessScriptStem() {
+        // CJK has no spaces, so the trailing word-char run is the whole clause since the last full
+        // stop — healing all of it makes the model re-emit text the user already typed, and every
+        // stem-consuming token counts against maxTokens (16 at the medium preset), so a 15-char stem
+        // ate most of the generation budget. Only the last few characters are healed.
+        // WAS: stem == "資料はもう準" (the entire run).
         let s = MidWordHealing.split(prefix: "資料はもう準")
-        XCTAssertEqual(s?.stem, "資料はもう準")  // all word chars, no boundary → whole thing is the stem
+        XCTAssertEqual(s?.stem, "はもう準")
+        XCTAssertEqual(s?.head, "資料")
+        XCTAssertEqual(s?.stem.count, MidWordHealing.maxSpacelessStem)
+        // …and head + stem still reconstructs the prefix exactly (the engine strips the stem back out).
+        XCTAssertEqual((s?.head ?? "") + (s?.stem ?? ""), "資料はもう準")
+    }
+
+    func testSplitCapsThaiStemAndNeverRejectsIt() {
+        // A long Thai run must be capped, not rejected by the maxStem rule — whitespace never breaks
+        // it, so `maxStem` would refuse to heal every Thai caret past 24 chars.
+        let prefix = "สวัสดีครับผมชื่อ"
+        let s = MidWordHealing.split(prefix: prefix)
+        XCTAssertNotNil(s)
+        XCTAssertEqual(s?.stem.count, MidWordHealing.maxSpacelessStem)
+        XCTAssertEqual((s?.head ?? "") + (s?.stem ?? ""), prefix)
+    }
+
+    func testSplitShorterThanTheSpacelessCapIsUnchanged() {
+        let s = MidWordHealing.split(prefix: "これは準")
+        XCTAssertEqual(s?.stem, "これは準")   // 4 chars — already at the cap, nothing trimmed
+        XCTAssertEqual(s?.head, "")
+    }
+
+    func testLatinStemStillRejectedWhenOverlong() {
+        // The spaceless cap must not leak into Latin: a 25-char Latin run is still a complete word,
+        // and healing it burns the constraint for no gain.
+        XCTAssertNil(MidWordHealing.split(prefix: "the " + String(repeating: "a", count: 25)))
     }
 
     // MARK: strip

--- a/Tests/ShadowtypeTests/ModelCardCopyTests.swift
+++ b/Tests/ShadowtypeTests/ModelCardCopyTests.swift
@@ -1,0 +1,105 @@
+// Onboarding model-card copy: the two strings that used to be constants asserting things that were
+// not true of the file in front of the user.
+//
+// Bug 1: the spec line hardcoded "Q4_K_M" for every catalog row, so the four Google QAT entries —
+// which are q4_0 — were mislabelled in the UI.
+// Bug 2: the status line read "Verified · GGUF ✓" after every download, while most catalog entries
+// ship `sha256: nil`; for those the only check was the 4-byte GGUF magic, which a truncated or
+// tampered multi-GB file passes trivially.
+//
+// Pure string logic, so this is hermetic — no window, no download, no model file.
+import XCTest
+@testable import Shadowtype
+
+final class ModelCardCopyTests: XCTestCase {
+
+    // MARK: spec line
+
+    func testSpecRendersTheEntrysOwnQuantization() {
+        XCTAssertEqual(ModelCardCopy.spec(quant: "Q4_K_M", approxRAMGB: 1.5),
+                       "Q4_K_M · on-device · ~1.5 GB RAM")
+        XCTAssertEqual(ModelCardCopy.spec(quant: "Q4_0", approxRAMGB: 3.4),
+                       "Q4_0 · on-device · ~3.4 GB RAM",
+                       "a q4_0 QAT build must not be advertised as Q4_K_M")
+    }
+
+    func testSpecFallsBackToNeutralGGUFWhenQuantIsUnknown() {
+        // Only BYOM/imported entries carry nil — their filename is the user's, so we cannot know the
+        // format. Naming a specific one would be a guess presented as fact.
+        XCTAssertEqual(ModelCardCopy.spec(quant: nil, approxRAMGB: 7.2),
+                       "GGUF · on-device · ~7.2 GB RAM")
+    }
+
+    /// The regression that motivated the field: drive the real catalog through the real copy function
+    /// and assert no entry is described with a format that isn't its own.
+    func testNoCatalogEntryIsMislabelled() {
+        for entry in ModelCatalog.entries {
+            let line = ModelCardCopy.spec(quant: entry.quant, approxRAMGB: entry.approxRAMGB)
+            guard let quant = entry.quant else {
+                XCTFail("catalog entry \(entry.id) has no quant — every shipped entry must record one")
+                continue
+            }
+            XCTAssertTrue(line.hasPrefix(quant + " · "),
+                          "\(entry.id) renders as \"\(line)\" but its file is \(quant)")
+            if quant != "Q4_K_M" {
+                XCTAssertFalse(line.contains("Q4_K_M"),
+                               "\(entry.id) is \(quant); the card must not claim Q4_K_M")
+            }
+        }
+    }
+
+    // MARK: installed status
+
+    func testHashVerifiedDownloadsMayClaimVerification() {
+        XCTAssertEqual(ModelCardCopy.installedStatus(.pinnedSHA256), "Verified · SHA-256 ✓")
+        XCTAssertEqual(ModelCardCopy.installedStatus(.linkedSHA256), "Verified · SHA-256 ✓")
+        XCTAssertNil(ModelCardCopy.installedNote(.pinnedSHA256))
+        XCTAssertNil(ModelCardCopy.installedNote(.linkedSHA256))
+    }
+
+    func testMagicBytesOnlyDownloadNeverClaimsVerification() {
+        let status = ModelCardCopy.installedStatus(.unverified)
+        XCTAssertFalse(status.lowercased().contains("verified"),
+                       "GGUF magic alone is not verification — \"\(status)\" must not say so")
+        XCTAssertEqual(status, "Installed · not checksummed")
+        // And the plain-language disclosure must actually appear, so the badge isn't the only signal.
+        let note = ModelCardCopy.installedNote(.unverified)
+        XCTAssertNotNil(note)
+        XCTAssertTrue(note?.contains("couldn't hash-verify") == true)
+    }
+
+    func testNothingDownloadedReportsNoVerdictEitherWay() {
+        // nil = the file was already on disk, so no verification ran this launch. That is NOT the same
+        // as "unverified", and the UI must neither claim a checksum nor warn about a missing one.
+        let status = ModelCardCopy.installedStatus(nil)
+        XCTAssertEqual(status, "Installed ✓")
+        XCTAssertFalse(status.lowercased().contains("verified"))
+        XCTAssertNil(ModelCardCopy.installedNote(nil))
+    }
+
+    /// Seam pin: the card's claim must be driven by the SAME verdict the downloader actually produces,
+    /// end to end. Walks ModelManager.verificationPlan (the real decision) into ModelCardCopy (the real
+    /// copy) and asserts the card says "SHA-256" exactly when a hash was genuinely compared. A future
+    /// `ModelVerification` case that skips a hash but is rendered as verified fails here.
+    func testCardClaimsAChecksumExactlyWhenTheDownloaderComparedOne() {
+        let hash = String(repeating: "a", count: 64)
+        let cases: [(pinned: String?, linked: String?)] = [
+            (hash, nil),            // catalog pin
+            (nil, hash),            // Hugging Face X-Linked-Etag
+            (hash, hash),           // both: the pin wins, still hashed
+            (nil, nil),             // neither: GGUF magic only
+            ("", ""),               // empty headers are not hashes
+        ]
+        for c in cases {
+            let plan = ModelManager.verificationPlan(pinnedSHA256: c.pinned, linkedSHA256: c.linked)
+            let status = ModelCardCopy.installedStatus(plan.outcome)
+            let hashed = plan.expected != nil
+            XCTAssertEqual(plan.outcome.isHashVerified, hashed,
+                           "verdict \(plan.outcome) disagrees with whether a hash was compared")
+            XCTAssertEqual(status.contains("SHA-256"), hashed,
+                           "pinned=\(String(describing: c.pinned)) linked=\(String(describing: c.linked)) "
+                           + "→ \"\(status)\"")
+            XCTAssertEqual(ModelCardCopy.installedNote(plan.outcome) == nil, hashed)
+        }
+    }
+}

--- a/Tests/ShadowtypeTests/ModelCatalogTests.swift
+++ b/Tests/ShadowtypeTests/ModelCatalogTests.swift
@@ -75,7 +75,42 @@ final class ModelCatalogTests: XCTestCase {
         }
     }
 
-    // MARK: - RAM gate (FR-LM-2, PRD §6 ~75% budget)
+    /// The model cards used to hardcode "Q4_K_M" for every row, mislabeling the four Google QAT `q4_0`
+    /// GGUFs. `quant` is the field the UI must render, so it has to be set and has to agree with the
+    /// actual file name — a copy-pasted entry with the wrong quant is exactly the mislabel we just fixed.
+    func testEveryEntryDeclaresItsQuantAndItMatchesTheFileName() {
+        for entry in ModelCatalog.entries {
+            guard let quant = entry.quant else {
+                XCTFail("\(entry.id): missing quant — the UI would have to guess")
+                continue
+            }
+            let file = entry.fileName.lowercased()
+            let expected: String
+            if file.contains("q4_k_m") {
+                expected = "Q4_K_M"
+            } else if file.contains("q4_0") {
+                expected = "Q4_0"
+            } else {
+                XCTFail("\(entry.id): filename \(entry.fileName) declares no recognizable quant")
+                continue
+            }
+            XCTAssertEqual(quant, expected, "\(entry.id): quant \(quant) contradicts file \(entry.fileName)")
+        }
+    }
+
+    /// Llama 3.1 8B Instruct was removed: dominated by the ~4B-class 2026 entries at twice their size,
+    /// a 2023-12 knowledge cutoff, the only non-permissive license in the catalog, and the only instruct
+    /// entry that violated the base-variant-for-raw-continuation rule. Guards against a revert.
+    func testLlama31IsNotInTheCatalog() {
+        XCTAssertFalse(ModelCatalog.entries.contains { $0.id.contains("llama") },
+                       "llama-3.1-8b-instruct was deliberately removed; do not re-add it")
+    }
+
+    // MARK: - RAM gate (FR-LM-2, PRD §6)
+    // The budget is min(75% of RAM, RAM - 3 GB OS floor) and the model costs weights + 10% KV cache
+    // (F16 KV at the engine's n_ctx=4096). The old gate compared 75% of RAM against the WEIGHTS ALONE,
+    // which left an 8 GB Mac 6.44 GB for the model and nothing for macOS, the app being typed into, or
+    // the KV cache — and on Apple Silicon the GPU shares that same unified pool.
 
     func testRamOKTrueForSmallModelOnBigMachine() {
         let small = ModelCatalogEntry(
@@ -90,33 +125,99 @@ final class ModelCatalogTests: XCTestCase {
             id: "huge", name: "Huge", fileName: "huge.gguf",
             url: URL(string: "https://example.com/huge.gguf")!,
             sha256: nil, approxRAMGB: 7.5, downloadGB: 4.9, paidOnly: true)
-        // 8 GB machine -> budget is 6 GB; a 7.5 GB model must be blocked.
+        // 8 GB machine -> budget is 5 GB (8 - 3 OS floor); a 7.5 GB model must be blocked.
         XCTAssertFalse(ModelCatalog.ramOK(for: huge, physicalBytes: machine(8)))
     }
 
-    func testRamOKBoundaryAtSeventyFivePercent() {
-        // Exactly at the 75% budget is allowed (<=). 6 GB model on an 8 GB machine: budget == 6 GB.
+    /// WAS `testRamOKBoundaryAtSeventyFivePercent`, which asserted a 6.0 GB model IS RAM-OK on an 8 GB
+    /// machine. That assertion LOCKED IN the bug: 6.0 GB of weights + ~0.6 GB of KV on an 8 GB Mac
+    /// leaves under 1.4 GB for macOS and the app being typed into, so it swaps. New expectation: with
+    /// the 3 GB OS floor the budget is 5 GB and a 6.0 GB model is correctly blocked.
+    func testRamOKBlocksSixGBModelOnEightGBMachine() {
         let edge = ModelCatalogEntry(
             id: "edge", name: "Edge", fileName: "edge.gguf",
             url: URL(string: "https://example.com/edge.gguf")!,
             sha256: nil, approxRAMGB: 6.0, downloadGB: 3.5, paidOnly: true)
-        XCTAssertTrue(ModelCatalog.ramOK(for: edge, physicalBytes: machine(8)))
+        XCTAssertFalse(ModelCatalog.ramOK(for: edge, physicalBytes: machine(8)),
+                       "6 GB weights + KV cannot coexist with macOS on an 8 GB Mac")
+    }
+
+    /// The concrete shipped case: Gemma 4 E4B (6.3 GB) reported RAM-OK on an 8 GB Mac under the old
+    /// weights-only 75% rule and so never got the "Tight on RAM" tag in the Models pane.
+    func testGemma4E4BIsNotRamOKOnEightGBMachine() {
+        let e4b = ModelCatalog.entries.first { $0.id == "gemma-4-e4b-it-qat-q4_0" }!
+        XCTAssertFalse(ModelCatalog.ramOK(for: e4b, physicalBytes: machine(8)),
+                       "E4B (6.3 GB) must be tagged tight on an 8 GB Mac")
+    }
+
+    func testRamOKBudgetBoundaryOnA16GBMachine() {
+        // 16 GB -> budget = min(12, 13) = 12 GB, and the model costs weights * 1.1 (KV cache).
+        // 10.0 GB of weights costs 11.0 -> fits; 11.0 GB costs 12.1 -> does not.
+        func entry(_ ram: Double) -> ModelCatalogEntry {
+            ModelCatalogEntry(
+                id: "edge-\(ram)", name: "Edge", fileName: "edge.gguf",
+                url: URL(string: "https://example.com/edge.gguf")!,
+                sha256: nil, approxRAMGB: ram, downloadGB: 1.0, paidOnly: false)
+        }
+        XCTAssertTrue(ModelCatalog.ramOK(for: entry(10.0), physicalBytes: machine(16)))
+        XCTAssertFalse(ModelCatalog.ramOK(for: entry(11.0), physicalBytes: machine(16)),
+                       "the KV cache term must push an 11 GB model past the 12 GB budget")
+    }
+
+    func testRamOKSeventyFivePercentStillBindsOnLargeMachines() {
+        // On a big Mac the OS floor is slack, so the original 75% headroom rule is what binds:
+        // 64 GB -> budget = min(48, 61) = 48; 44 GB of weights costs 48.4 and must be blocked.
+        let big = ModelCatalogEntry(
+            id: "big", name: "Big", fileName: "big.gguf",
+            url: URL(string: "https://example.com/big.gguf")!,
+            sha256: nil, approxRAMGB: 44.0, downloadGB: 30.0, paidOnly: false)
+        XCTAssertFalse(ModelCatalog.ramOK(for: big, physicalBytes: machine(64)))
     }
 
     // MARK: - Recommendation (FR-LM-3)
 
-    func testRecommendedPicksWithinRAM() {
-        // On a generous machine, every entry fits, so the recommendation is the largest entry and it
-        // must itself be RAM-OK.
-        let rec = ModelCatalog.recommended(physicalBytes: machine(64))
-        XCTAssertTrue(ModelCatalog.ramOK(for: rec, physicalBytes: machine(64)))
-        let largest = ModelCatalog.entries.max(by: { $0.approxRAMGB < $1.approxRAMGB })
-        XCTAssertEqual(rec.id, largest?.id)
+    /// WAS `testRecommendedPicksWithinRAM`, which asserted the recommendation on a 64 GB Mac IS the
+    /// LARGEST catalog entry. That assertion LOCKED IN the wrong objective: `recommended()` is the
+    /// pre-selected FIRST-RUN download, and the largest entry (qwen3-30b-a3b, 18.6 GB down / ~20 GB
+    /// resident) cannot produce a first token inside the coordinator's ~400 ms deadline on a ~1500-token
+    /// prompt — the ghost is silently dropped and the product reads as broken. New expectation: even a
+    /// 64 GB Mac is recommended the 4B class; the big entries stay manually selectable.
+    func testRecommendedIsCappedAtTheFourBClassEvenOnHugeMachines() {
+        for gigs: UInt64 in [16, 24, 32, 64, 128] {
+            let rec = ModelCatalog.recommended(physicalBytes: machine(gigs))
+            XCTAssertEqual(rec.id, "qwen3-4b-base-q4_k_m", "\(gigs)GB recommended \(rec.id)")
+            XCTAssertTrue(ModelCatalog.ramOK(for: rec, physicalBytes: machine(gigs)))
+        }
+        let largest = ModelCatalog.entries.max(by: { $0.approxRAMGB < $1.approxRAMGB })!
+        XCTAssertNotEqual(ModelCatalog.recommended(physicalBytes: machine(64)).id, largest.id,
+                          "the recommendation must not be 'largest that fits'")
     }
 
-    func testRecommendedFitsConstrainedMachine() {
-        // On a tight machine, the recommendation must be one that actually fits the 75% budget.
+    /// The "product reads as broken" regression, pinned STRUCTURALLY so it survives a catalog reshuffle
+    /// that renames or replaces `qwen3-4b-base-q4_k_m`: on a 32 GB Mac the first-run pick must stay in
+    /// the small class, because anything heavier misses the ~400 ms first-token deadline and the ghost
+    /// never appears at all. Bounded by `recommendedCapRAMGB`, not by a hardcoded id.
+    func testRecommendedOnAThirtyTwoGBMacStaysInTheFastClass() {
+        let rec = ModelCatalog.recommended(physicalBytes: machine(32))
+        let cap = ModelCatalog.recommendedCapRAMGB(physicalBytes: machine(32))
+        XCTAssertLessThanOrEqual(rec.approxRAMGB, cap,
+                                 "32GB pick \(rec.id) (\(rec.approxRAMGB) GB) exceeds the deadline cap")
+        XCTAssertLessThanOrEqual(rec.approxRAMGB, 4.0, "32GB pick must stay in the ~4B class")
+        // The failure this encodes: an 18.6 GB 30B MoE fits 32 GB of RAM and was picked by the old
+        // largest-that-fits rule, then showed no ghost.
+        let heaviest = ModelCatalog.entries.max(by: { $0.approxRAMGB < $1.approxRAMGB })!
+        XCTAssertTrue(ModelCatalog.ramOK(for: heaviest, physicalBytes: machine(32)),
+                      "precondition: the heaviest entry does fit 32 GB — that is why the cap exists")
+        XCTAssertNotEqual(rec.id, heaviest.id)
+        // A base model, so it continues raw-prefix text instead of emitting end-of-turn (bug 3).
+        XCTAssertFalse(rec.isInstruct)
+    }
+
+    func testRecommendedOnEightGBIsTheSmallGemma() {
+        // 8 GB Macs share unified memory with the browser/editor being typed into, so the first-run
+        // pick stays at the ~1.5 GB class rather than the 4B that would technically fit the budget.
         let rec = ModelCatalog.recommended(physicalBytes: machine(8))
+        XCTAssertEqual(rec.id, "gemma-3-1b-pt-q4_k_m")
         XCTAssertTrue(ModelCatalog.ramOK(for: rec, physicalBytes: machine(8)))
     }
 
@@ -144,27 +245,40 @@ final class ModelCatalogTests: XCTestCase {
     }
 
     func testRecommendedPrefersBaseOverLargerInstruct() {
-        // 17 GB (75% ≈ 12.75): Llama-3.1-8B-Instruct (7.5) is the largest-that-fits overall, but the
-        // near-identical Qwen3-8B-Base (6.8) must win — the exact case that put this user on a
-        // completion-dropping instruct model.
+        // WAS: 17 GB expected qwen3-8b-base (6.8), beating the now-removed Llama-3.1-8B-Instruct (7.5).
+        // With the first-token-deadline cap the pick is the 4B base instead — still a BASE model, which
+        // is what this test is about: instruct models emit end-of-turn on dangling prefixes and drop
+        // the ghost, so the recommender must never hand a first-run user one.
         let rec = ModelCatalog.recommended(physicalBytes: machine(17))
         XCTAssertFalse(rec.isInstruct)
-        XCTAssertEqual(rec.id, "qwen3-8b-base-q4_k_m")
+        XCTAssertEqual(rec.id, "qwen3-4b-base-q4_k_m")
     }
 
     func testRecommendedPickIsStillRamSafe() {
+        // 4 GB is below the OS floor + the smallest model, so nothing clears the budget there and the
+        // documented fallback (smallest entry, knowingly over budget) applies — the app must still have
+        // something to load. Everywhere else the pick must be genuinely RAM-safe.
+        let smallest = ModelCatalog.entries.min(by: { $0.approxRAMGB < $1.approxRAMGB })!
         for gigs: UInt64 in [4, 8, 16, 17, 24, 32, 64] {
             let rec = ModelCatalog.recommended(physicalBytes: machine(gigs))
-            XCTAssertTrue(ModelCatalog.ramOK(for: rec, physicalBytes: machine(gigs)),
-                          "\(gigs)GB: recommended \(rec.id) exceeds the RAM budget")
+            let nothingFits = !ModelCatalog.entries.contains {
+                ModelCatalog.ramOK(for: $0, physicalBytes: machine(gigs))
+            }
+            if nothingFits {
+                XCTAssertEqual(rec.id, smallest.id, "\(gigs)GB: fallback must be the smallest entry")
+            } else {
+                XCTAssertTrue(ModelCatalog.ramOK(for: rec, physicalBytes: machine(gigs)),
+                              "\(gigs)GB: recommended \(rec.id) exceeds the RAM budget")
+            }
         }
     }
 
     func testInstructFlagTagsExactlyTheInstructEntries() {
         let instruct = Set(ModelCatalog.entries.filter { $0.isInstruct }.map { $0.id })
+        // Only the Gemma 4 family, which ships instruct-only (no base GGUF exists for it).
         XCTAssertEqual(instruct, [
             "gemma-4-e2b-it-qat-q4_0", "gemma-4-e4b-it-qat-q4_0", "gemma-4-12b-it-qat-q4_0",
-            "llama-3.1-8b-instruct-q4_k_m", "gemma-4-26b-a4b-it-qat-q4_0",
+            "gemma-4-26b-a4b-it-qat-q4_0",
         ])
     }
 

--- a/Tests/ShadowtypeTests/ModelDownloadVerificationTests.swift
+++ b/Tests/ShadowtypeTests/ModelDownloadVerificationTests.swift
@@ -1,0 +1,217 @@
+// ModelManager download integrity: the pure pieces of "was this multi-GB file actually verified?"
+// and of the resumable-download bookkeeping. Hermetic — no network, no model, no real download.
+//
+// Background: the onboarding copy promised every model was "verified by checksum" while 9 of 11
+// catalog entries ship `sha256: nil`, so the only real check was the 4-byte GGUF magic. These cover
+// the replacement: Hugging Face's `X-Linked-Etag` (the LFS object's SHA-256) and `X-Linked-Size`.
+import XCTest
+@testable import Shadowtype
+
+final class ModelLinkedHeaderTests: XCTestCase {
+
+    func testParsesQuotedLinkedETag() {
+        let sha = "caf1c278f8a8ba1e4605af68b6c17c91a18bf315b38bd52efc542d009d19dd57"
+        XCTAssertEqual(ModelManager.parseLinkedSHA256("\"\(sha)\""), sha)
+        XCTAssertEqual(ModelManager.parseLinkedSHA256(sha), sha)
+        XCTAssertEqual(ModelManager.parseLinkedSHA256("  \"\(sha)\"  "), sha)
+        XCTAssertEqual(ModelManager.parseLinkedSHA256("W/\"\(sha.uppercased())\""), sha,
+                       "weak validator + uppercase hex must normalize to the lowercase digest")
+    }
+
+    func testRejectsNonSHA256ETags() {
+        // Non-LFS files get an arbitrary/md5-shaped ETag. Verifying against one can only ever fail,
+        // so it must be treated as "no hash available" instead.
+        XCTAssertNil(ModelManager.parseLinkedSHA256(nil))
+        XCTAssertNil(ModelManager.parseLinkedSHA256(""))
+        XCTAssertNil(ModelManager.parseLinkedSHA256("\"\""))
+        XCTAssertNil(ModelManager.parseLinkedSHA256("\"9bb1e4605af68b6c17c91a18bf315b38\""), "md5 length")
+        XCTAssertNil(ModelManager.parseLinkedSHA256(String(repeating: "z", count: 64)), "not hex")
+        XCTAssertNil(ModelManager.parseLinkedSHA256("\"686897696a7c876b7e\"-gzip"))
+    }
+
+    func testParsesLinkedSize() {
+        XCTAssertEqual(ModelManager.parseLinkedSize("806056864"), 806_056_864)
+        XCTAssertEqual(ModelManager.parseLinkedSize(" 806056864 "), 806_056_864)
+        XCTAssertNil(ModelManager.parseLinkedSize(nil))
+        XCTAssertNil(ModelManager.parseLinkedSize(""))
+        XCTAssertNil(ModelManager.parseLinkedSize("1.2e9"))
+        XCTAssertNil(ModelManager.parseLinkedSize("0"), "a zero-byte object is not a usable size")
+        XCTAssertNil(ModelManager.parseLinkedSize("-5"))
+    }
+}
+
+final class ModelVerificationPlanTests: XCTestCase {
+    private let pinned = "caf1c278f8a8ba1e4605af68b6c17c91a18bf315b38bd52efc542d009d19dd57"
+    private let linked = "0000000000000000000000000000000000000000000000000000000000000001"
+
+    func testPinnedHashWinsOverServerReportedOne() {
+        // If HF ever serves different bytes under the same URL, that must be a hard failure — not a
+        // silent pass because the server's header agrees with the server's bytes.
+        let plan = ModelManager.verificationPlan(pinnedSHA256: pinned, linkedSHA256: linked)
+        XCTAssertEqual(plan.expected, pinned)
+        XCTAssertEqual(plan.outcome, .pinnedSHA256)
+    }
+
+    func testLinkedHashUsedWhenNothingIsPinned() {
+        let plan = ModelManager.verificationPlan(pinnedSHA256: nil, linkedSHA256: linked)
+        XCTAssertEqual(plan.expected, linked)
+        XCTAssertEqual(plan.outcome, .linkedSHA256)
+        XCTAssertTrue(plan.outcome.isHashVerified,
+                      "a header-verified download IS checksum-verified; the UI may say so")
+    }
+
+    func testNoHashAnywhereIsReportedAsUnverified() {
+        let plan = ModelManager.verificationPlan(pinnedSHA256: nil, linkedSHA256: nil)
+        XCTAssertNil(plan.expected)
+        XCTAssertEqual(plan.outcome, .unverified)
+        XCTAssertFalse(plan.outcome.isHashVerified,
+                       "GGUF-magic-only must NOT be presented to the user as 'verified by checksum'")
+        // An empty string is a missing hash, not a hash to compare against.
+        XCTAssertEqual(ModelManager.verificationPlan(pinnedSHA256: "", linkedSHA256: "").outcome,
+                       .unverified)
+    }
+}
+
+final class ModelDownloadSizeCheckTests: XCTestCase {
+
+    func testMatchingSizePasses() {
+        XCTAssertNoThrow(try ModelManager.checkDownloadedSize(expected: 806_056_864,
+                                                              actual: 806_056_864))
+    }
+
+    func testTruncatedDownloadIsRejected() {
+        // The common real-world failure: the first 4 bytes are a valid GGUF magic, so nothing but the
+        // byte count catches it.
+        XCTAssertThrowsError(try ModelManager.checkDownloadedSize(expected: 806_056_864,
+                                                                  actual: 12_345)) { error in
+            guard case let ModelManagerError.sizeMismatch(expected, actual) = error else {
+                XCTFail("expected .sizeMismatch, got \(error)"); return
+            }
+            XCTAssertEqual(expected, 806_056_864)
+            XCTAssertEqual(actual, 12_345)
+            let msg = (error as? LocalizedError)?.errorDescription ?? ""
+            XCTAssertTrue(msg.contains("incomplete"), msg)
+        }
+    }
+}
+
+final class ModelResumeDataTests: XCTestCase {
+
+    private func makeResumeBlob() -> Data {
+        let plist: [String: Any] = [
+            "NSURLSessionResumeInfoVersion": 2,
+            "NSURLSessionDownloadURL": "https://huggingface.co/o/r/resolve/main/m.gguf",
+        ]
+        return try! PropertyListSerialization.data(fromPropertyList: plist, format: .binary, options: 0)
+    }
+
+    func testResumeBlobLivesNextToTheDownload() {
+        let dest = URL(fileURLWithPath: "/tmp/models/gemma-3-1b-pt-Q4_K_M.gguf")
+        XCTAssertEqual(ModelManager.resumeDataURL(for: dest).lastPathComponent,
+                       "gemma-3-1b-pt-Q4_K_M.gguf.resume")
+    }
+
+    func testPlausibleResumeDataAcceptsRealBlobShape() {
+        XCTAssertTrue(ModelManager.isPlausibleResumeData(makeResumeBlob()))
+    }
+
+    func testPlausibleResumeDataRejectsGarbage() {
+        // Handing URLSession a non-plist blob has historically raised an uncatchable ObjC exception,
+        // so the shape check has to happen before downloadTask(withResumeData:).
+        XCTAssertFalse(ModelManager.isPlausibleResumeData(Data()))
+        XCTAssertFalse(ModelManager.isPlausibleResumeData(Data([0x00, 0xFF, 0x10, 0x42])))
+        XCTAssertFalse(ModelManager.isPlausibleResumeData(Data("not a plist at all".utf8)))
+        let arrayPlist = try! PropertyListSerialization.data(fromPropertyList: ["a", "b"],
+                                                            format: .binary, options: 0)
+        XCTAssertFalse(ModelManager.isPlausibleResumeData(arrayPlist))
+        let wrongKeys = try! PropertyListSerialization.data(fromPropertyList: ["unrelated": 1],
+                                                           format: .binary, options: 0)
+        XCTAssertFalse(ModelManager.isPlausibleResumeData(wrongKeys))
+    }
+
+    func testReadResumeDataReturnsBlobAndDropsCorruptOne() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("shadowtype-resume-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let missing = dir.appendingPathComponent("absent.gguf.resume")
+        XCTAssertNil(ModelManager.readResumeData(at: missing))
+
+        let good = dir.appendingPathComponent("good.gguf.resume")
+        let blob = makeResumeBlob()
+        try blob.write(to: good)
+        XCTAssertEqual(ModelManager.readResumeData(at: good), blob)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: good.path),
+                      "a usable blob must survive the read")
+
+        // A truncated/corrupt blob (crash mid-write) must be discarded, otherwise every future attempt
+        // would try to resume from it and fail forever.
+        let bad = dir.appendingPathComponent("bad.gguf.resume")
+        try Data([0x01, 0x02, 0x03]).write(to: bad)
+        XCTAssertNil(ModelManager.readResumeData(at: bad))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: bad.path),
+                       "an unusable blob must be deleted so the next attempt restarts clean")
+    }
+}
+
+// A resume blob must be keyed by SOURCE as well as destination. `downloadTask(withResumeData:)` ignores
+// the request it is handed and continues the URL archived inside the blob, and Hugging Face filenames are
+// not unique across repos — `model.Q4_K_M.gguf` from mradermacher, bartowski and unsloth all land on the
+// same imported path. Keyed by destination alone, a cancelled import of repo A leaves a blob that a later
+// import of repo B's identically-named file picks up, and B silently receives A's bytes.
+final class ResumeDataKeyingTests: XCTestCase {
+    private let dest = URL(fileURLWithPath: "/tmp/imported/model.Q4_K_M.gguf")
+
+    func testSameFilenameFromDifferentReposDoesNotShareAResumeBlob() {
+        let a = ModelManager.resumeDataURL(
+            for: dest, source: URL(string: "https://huggingface.co/repoA/resolve/main/model.Q4_K_M.gguf")!)
+        let b = ModelManager.resumeDataURL(
+            for: dest, source: URL(string: "https://huggingface.co/repoB/resolve/main/model.Q4_K_M.gguf")!)
+        XCTAssertNotEqual(a, b, "identically-named files from different repos collided on one resume blob")
+    }
+
+    func testSameSourceIsStableSoAResumeCanActuallyBeFound() {
+        let url = URL(string: "https://huggingface.co/repoA/resolve/main/model.Q4_K_M.gguf")!
+        XCTAssertEqual(ModelManager.resumeDataURL(for: dest, source: url),
+                       ModelManager.resumeDataURL(for: dest, source: url))
+    }
+
+    func testResumeBlobStaysBesideItsDownload() {
+        let url = URL(string: "https://example.com/m.gguf")!
+        let resume = ModelManager.resumeDataURL(for: dest, source: url)
+        XCTAssertEqual(resume.deletingLastPathComponent(), dest.deletingLastPathComponent())
+        XCTAssertEqual(resume.pathExtension, "resume")
+    }
+}
+
+// The `X-Linked-*` headers ride on Hugging Face's `resolve` 302. A resumed task continues the CDN URL
+// archived in the blob and never replays that hop, so without carrying them forward a resumed download
+// silently degrades to the GGUF-magic check — in exactly the flow resume exists for.
+final class LinkedMetadataCarryTests: XCTestCase {
+    private func tempResumeURL() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("st-meta-\(UUID().uuidString).resume")
+    }
+
+    func testMetadataRoundTripsAcrossAResume() {
+        let resume = tempResumeURL()
+        defer { try? FileManager.default.removeItem(at: ModelManager.linkedMetadataURL(for: resume)) }
+        let sha = String(repeating: "a", count: 64)
+        ModelManager.writeLinkedMetadata(.init(sha256: sha, size: 1234), besideResumeAt: resume)
+        let read = ModelManager.readLinkedMetadata(besideResumeAt: resume)
+        XCTAssertEqual(read?.sha256, sha)
+        XCTAssertEqual(read?.size, 1234)
+    }
+
+    func testEmptyMetadataIsNotWritten() {
+        let resume = tempResumeURL()
+        ModelManager.writeLinkedMetadata(.init(sha256: nil, size: nil), besideResumeAt: resume)
+        XCTAssertNil(ModelManager.readLinkedMetadata(besideResumeAt: resume),
+                     "an empty sidecar would masquerade as carried verification data")
+    }
+
+    func testMissingSidecarReadsAsNil() {
+        XCTAssertNil(ModelManager.readLinkedMetadata(besideResumeAt: tempResumeURL()))
+    }
+}

--- a/Tests/ShadowtypeTests/OCRCleanupTests.swift
+++ b/Tests/ShadowtypeTests/OCRCleanupTests.swift
@@ -428,8 +428,8 @@ final class OCRCleanupTests: XCTestCase {
             instruction: nil, styleHint: nil, styleEnabled: false,
             clipboard: nil, clipboardEnabled: false,
             ocr: ctx, ocrEnabled: true, steerLanguageName: "Catalan")
-        XCTAssertTrue(steered.contains("\n\nText (in Catalan):\n"))
-        XCTAssertFalse(steered.contains("\n\nText:\n"))
+        XCTAssertTrue(steered.prompt.contains("\n\nText (in Catalan):\n"))
+        XCTAssertFalse(steered.prompt.contains("\n\nText:\n"))
 
         // nil steer is byte-identical to the bare-marker output (guards KV-reuse identity).
         let bare = CompletionCoordinator.assemblePrompt(
@@ -437,8 +437,8 @@ final class OCRCleanupTests: XCTestCase {
             instruction: nil, styleHint: nil, styleEnabled: false,
             clipboard: nil, clipboardEnabled: false,
             ocr: ctx, ocrEnabled: true)
-        XCTAssertTrue(bare.contains("\n\nText:\n"))
-        XCTAssertFalse(bare.contains("Text (in"))
+        XCTAssertTrue(bare.prompt.contains("\n\nText:\n"))
+        XCTAssertFalse(bare.prompt.contains("Text (in"))
     }
 
     func testSuggestionConflictsWithContext() {

--- a/Tests/ShadowtypeTests/OCRCleanupTests.swift
+++ b/Tests/ShadowtypeTests/OCRCleanupTests.swift
@@ -174,6 +174,89 @@ final class OCRCleanupTests: XCTestCase {
         XCTAssertNil(ScreenContextProvider.removingDraftEcho("Lighter apple", draft: "Lighter apple"))
     }
 
+    // THE STALE CASE. The capture is throttled to <=1/s, so between shots the CAPTURED draft line is a
+    // SHORTER prefix of what the user has now typed. The old one-directional match (`t == tail ||
+    // t.hasPrefix(tail)`) went false the instant the user typed one more character, the line stopped
+    // being filtered, and the draft echoed back into the `Context:` block — the doc-echo word-salad, and
+    // a per-keystroke mutation of the prompt head that also kills anchored KV reuse.
+    func testRemovingDraftEchoStripsStaleShorterCapturedLine() {
+        let captured = "Can you review the deployment plan before Friday?\nThe launch checklist is"
+        // The user has typed well past the captured state of their own line.
+        let draft = "The launch checklist is nearly done, I just need"
+        let out = ScreenContextProvider.removingDraftEcho(captured, draft: draft)
+        XCTAssertEqual(out, "Can you review the deployment plan before Friday?")
+    }
+
+    // …and it must stay stripped for EVERY later keystroke, i.e. the cleaned block is byte-stable while
+    // the draft grows. That stability is the whole point: the block sits in front of the prefix.
+    func testRemovingDraftEchoIsStableAsTheDraftGrows() {
+        let captured = "Can you review the deployment plan before Friday?\nThe launch checklist is"
+        let base = "The launch checklist is"
+        let growth = [" nearly", " nearly done", " nearly done, I just need", " nearly done, I just need to"]
+        let outputs = growth.map { ScreenContextProvider.removingDraftEcho(captured, draft: base + $0) }
+        for out in outputs {
+            XCTAssertEqual(out, "Can you review the deployment plan before Friday?")
+        }
+    }
+
+    // The reverse match must not over-filter: a SHORT generic captured line is a prefix of half the
+    // drafts on screen, so it stays (only lines at least `minStaleLen` long can match backwards).
+    func testRemovingDraftEchoKeepsShortGenericLineThatPrefixesTheDraft() {
+        let captured = "Hi Ana\nAre we still on for the design review this afternoon?"
+        let out = ScreenContextProvider.removingDraftEcho(captured, draft: "Hi Ana, thanks for the notes")
+        XCTAssertEqual(out, captured)
+    }
+
+    // MARK: - clamp (line-boundary tail: the prompt head must not slide per keystroke)
+
+    func testClampCutsOnALineBoundary() throws {
+        let text = "line one is here\nline two is here\nline three is here"
+        // Budget fits the last two lines (17 + 1 + 19 = 37) but not the first.
+        let out = try XCTUnwrap(ScreenContextProvider.clamp(text, to: 40))
+        XCTAssertEqual(out, "line two is here\nline three is here")
+        XCTAssertFalse(out.hasPrefix("e one"))    // never a mid-line character cut
+    }
+
+    // The regression this replaces: a raw character suffix moved by one byte for every character that
+    // appeared on screen, so the kept window — and the `Context:` block built from it — changed
+    // byte-for-byte on every fire, and the engine's longest-common-prefix KV reuse found nothing.
+    func testClampWindowHoldsStillWhileTheLastLineGrows() {
+        let head = "an older message that is still on screen\nsome more context above the caret\n"
+        var previous: String?
+        for suffix in ["a", "ab", "abc", "abcd", "abcde"] {
+            let out = ScreenContextProvider.clamp(head + "draft " + suffix, to: 80)
+            let keptHead = out.map { String($0.prefix(20)) }
+            if let previous { XCTAssertEqual(keptHead, previous) }
+            previous = keptHead
+        }
+    }
+
+    func testClampFallsBackToCharacterCutForOneOverlongLine() {
+        let single = String(repeating: "x", count: 50)
+        XCTAssertEqual(ScreenContextProvider.clamp(single, to: 10)?.count, 10)
+    }
+
+    // MARK: - language-drift split (per-generation prefix read vs per-tick suggestion read)
+
+    // The composed entry point and the split pair must agree; the split exists only so the prefix side
+    // can be computed once per generation instead of once per ~33 ms render tick.
+    func testLanguageDriftSplitMatchesComposedForm() {
+        let prefix = "Bon dia, aquest matí he estat revisant el pressupost i encara falten dades del proveïdor."
+        let suggestion = "and then we should ship the release"
+        let composed = CompletionCoordinator.languageDrifts(prefix: prefix, suggestion: suggestion)
+        let split = CompletionCoordinator.languageDrifts(
+            prefixLanguage: CompletionCoordinator.driftPrefixLanguage(prefix), suggestion: suggestion)
+        XCTAssertEqual(composed, split)
+    }
+
+    // A short prefix yields no latched language, and the guard must then never fire — same conservative
+    // bail the composed form has always had.
+    func testDriftPrefixLanguageIsNilForShortPrefixSoGuardNeverFires() {
+        XCTAssertNil(CompletionCoordinator.driftPrefixLanguage("hola"))
+        XCTAssertFalse(CompletionCoordinator.languageDrifts(prefixLanguage: nil,
+                                                            suggestion: "a clearly English continuation"))
+    }
+
     // MARK: - ocrTextEquivalent (re-capture change guard: only a meaningful change busts the KV cache)
 
     func testOCREquivalentIgnoresWhitespaceReflow() {

--- a/Tests/ShadowtypeTests/PostCaretContextTests.swift
+++ b/Tests/ShadowtypeTests/PostCaretContextTests.swift
@@ -1,0 +1,157 @@
+// Post-caret conditioning (item 14): the model used to be told NOTHING about the text after the caret.
+// caretAtLineEnd() only means "the next character is a newline" — not end-of-document — so editing
+// paragraph 2 of a 5-paragraph mail, the completion happily duplicated or contradicted what sat three
+// lines below. assemblePrompt now carries an `After the cursor:` block, and these tests pin the two
+// properties that make it safe: it never starves the caret text, and it never moves the prompt HEAD
+// during a typing burst (the head is what the engine's longest-common-prefix KV reuse matches on).
+import XCTest
+@testable import Shadowtype
+
+final class PostCaretContextTests: XCTestCase {
+
+    private let marker = "\n\nText:\n"
+
+    private func assemble(prefix: String, postCaret: String?, budget: Int = 4000,
+                          ocr: String? = nil) -> String {
+        CompletionCoordinator.assemblePrompt(
+            prefix: prefix, isLicensed: true,
+            instruction: nil, styleHint: nil, styleEnabled: false,
+            clipboard: nil, clipboardEnabled: false,
+            ocr: ocr, ocrEnabled: ocr != nil,
+            postCaret: postCaret,
+            totalChars: budget).prompt
+    }
+
+    // MARK: - The block itself
+
+    func testBlockSitsImmediatelyBeforeTheTextMarker() {
+        let p = assemble(prefix: "Thanks for the ", postCaret: "\n\nBest,\nDario")
+        XCTAssertEqual(p, "Context:\nAfter the cursor:\nBest,\nDario\n\nText:\nThanks for the")
+    }
+
+    // Rendered LAST of the context blocks: adjacency to the `Text:` marker is what makes the
+    // before/after relationship legible to a base model, and appending at the end leaves every earlier
+    // block's bytes untouched so a fire with the block still shares a KV prefix with one without it.
+    func testBlockRendersAfterScreenContext() {
+        let p = assemble(prefix: "so I ", postCaret: "and then we can ship it.",
+                         ocr: "the meeting is on Thursday")
+        let ocrAt = p.range(of: "the meeting is on Thursday")!.lowerBound
+        let postAt = p.range(of: "After the cursor:")!.lowerBound
+        XCTAssertLessThan(ocrAt, postAt)
+        XCTAssertTrue(p.hasSuffix("\(marker)so I"))
+    }
+
+    // The label must not contain `Text:` / `Text (`: those are literal stop markers on the rewrite path
+    // (SamplingParams.rewriteDefaults) and the marker this very prompt ends with. A block header that
+    // collided with them would be a stop string embedded in the prompt.
+    func testBlockLabelDoesNotCollideWithTheStopMarkers() {
+        let block = CompletionCoordinator.postCaretBlock("something follows")!
+        XCTAssertFalse(block.contains("Text:"))
+        XCTAssertFalse(block.contains("Text ("))
+    }
+
+    // MARK: - Gating
+
+    func testNoPostCaretTextIsByteIdenticalToTheOldPrompt() {
+        let baseline = assemble(prefix: "the quick brown", postCaret: nil)
+        XCTAssertEqual(baseline, "the quick brown")   // bare prefix, no framing at all
+        // Whitespace-only (the caret sitting above a blank line, or trailing newlines at end of
+        // document) says nothing and must not introduce a block — nor let the head appear/disappear as
+        // that whitespace churns.
+        for empty in ["", "\n", "\n\n\n", "   ", " \n \n"] {
+            XCTAssertEqual(assemble(prefix: "the quick brown", postCaret: empty), baseline, "\(empty.debugDescription)")
+        }
+        XCTAssertNil(CompletionCoordinator.postCaretBlock("\n\n"))
+        XCTAssertNil(CompletionCoordinator.postCaretBlock(nil))
+    }
+
+    // Shell mode never reaches assemblePrompt at all — assembleShellPrompt is a separate few-shot
+    // `$ command` framing with no context blocks — so the post-caret block can't leak into a terminal.
+    func testShellPromptCarriesNoPostCaretBlock() {
+        let p = CompletionCoordinator.assembleShellPrompt(prefix: "git che",
+                                                          terminalBuffer: "$ git status\n$ ")
+        XCTAssertFalse(p.contains("After the cursor:"))
+    }
+
+    // MARK: - Truncation direction
+
+    func testTruncationKeepsTheTextNEARESTTheCaret() {
+        let near = String(repeating: "near ", count: 40)     // 200 bytes
+        let far  = String(repeating: "far ", count: 40)
+        let block = CompletionCoordinator.postCaretBlock(near + far, maxBytes: 100)!
+        XCTAssertTrue(block.hasPrefix("After the cursor:\nnear near"))
+        XCTAssertFalse(block.contains("far"))
+        // The header is not charged against maxBytes — the cap bounds the post-caret TEXT.
+        XCTAssertEqual(PromptSectionBudget.cost(block.replacingOccurrences(of: "After the cursor:\n", with: "")), 100)
+    }
+
+    func testHeadWindowNeverSplitsAMultiByteCharacter() {
+        // "é" is 2 UTF-8 bytes: a 3-byte window over "aéb" must keep "aé", not half of "é".
+        XCTAssertEqual(PromptSectionBudget.headWithinCost("aéb", maxCost: 3), "aé")
+        XCTAssertEqual(PromptSectionBudget.headWithinCost("aéb", maxCost: 2), "a")
+        XCTAssertEqual(PromptSectionBudget.headWithinCost("aéb", maxCost: 0), "")
+        XCTAssertEqual(PromptSectionBudget.headWithinCost("aéb", maxCost: 99), "aéb")
+    }
+
+    // MARK: - KV stability (the make-or-break: this block sits in FRONT of the prefix)
+
+    // The text after the caret does not change while the user types before it, so the block must not
+    // either. With the head byte-identical and the prefix only growing, each prompt is a STRICT
+    // EXTENSION of the previous one — exactly the shape InferenceEngine's longest-common-prefix reuse
+    // needs to skip re-prefilling the context region on every keystroke.
+    func testPromptHeadIsByteStableAcrossATypingBurst() {
+        let suffix = "\n\nThe deadline is Friday and the venue has changed to the annex."
+        let typed = "Hi Ana, I wanted to check whether the room booking still stands"
+        var prompts: [String] = []
+        for n in stride(from: 8, through: typed.count, by: 1) {
+            prompts.append(assemble(prefix: String(typed.prefix(n)), postCaret: suffix))
+        }
+        let head = String(prompts[0][..<prompts[0].range(of: marker)!.upperBound])
+        for p in prompts {
+            XCTAssertTrue(p.hasPrefix(head), "prompt head moved: \(p.prefix(120).debugDescription)")
+        }
+        // …and strictly extending, keystroke to keystroke (a trailing-space keystroke is trimmed away by
+        // assemblePrompt, so compare only the strictly-growing steps).
+        for (a, b) in zip(prompts, prompts.dropFirst()) where a.count < b.count {
+            XCTAssertTrue(b.hasPrefix(a), "not a strict extension at \(a.count) -> \(b.count)")
+        }
+    }
+
+    // Under a budget tight enough to bind, the block is taken WHOLE or dropped — never re-cut to
+    // "whatever the growing prefix left over", which would shrink the prompt head by a few bytes per
+    // keystroke and force a cold re-prefill on every fire.
+    func testBlockIsNeverPartiallyTrimmedAsThePrefixGrows() {
+        let suffix = String(repeating: "tail ", count: 12)          // 60 bytes
+        let whole = CompletionCoordinator.postCaretBlock(suffix)!
+        var seenWhole = false, seenAbsent = false
+        for n in stride(from: 60, through: 200, by: 1) {
+            let p = assemble(prefix: String(repeating: "a", count: n), postCaret: suffix, budget: 200)
+            if p.contains("After the cursor:") {
+                XCTAssertTrue(p.contains(whole), "post-caret block was mutated at prefix \(n)")
+                seenWhole = true
+            } else {
+                seenAbsent = true
+            }
+        }
+        XCTAssertTrue(seenWhole, "budget never left room — the test proves nothing")
+        XCTAssertTrue(seenAbsent, "budget never bound — the test proves nothing")
+    }
+
+    // MARK: - Budget rank
+
+    // Below the prefix: the caret text is never starved to make room for the post-caret block.
+    func testCaretTextIsNeverStarvedByThePostCaretBlock() {
+        let draft = "the important thing I am actually writing right now at the caret"
+        let p = assemble(prefix: draft, postCaret: String(repeating: "z ", count: 400), budget: 120)
+        XCTAssertTrue(p.hasSuffix("at the caret"), "\(p.debugDescription)")
+    }
+
+    // Above screen context, deliberately. The OCR block declares its whole length as maxChars, so under
+    // a binding budget it consumes everything the higher priorities left; ranked below it, the
+    // post-caret block would be dead weight in practice whenever screen context is on.
+    func testPostCaretOutranksScreenContextUnderPressure() {
+        let p = assemble(prefix: "so I ", postCaret: "and we ship on Friday.",
+                         budget: 120, ocr: String(repeating: "screen noise ", count: 40))
+        XCTAssertTrue(p.contains("and we ship on Friday."))
+    }
+}

--- a/Tests/ShadowtypeTests/PowerPolicyTests.swift
+++ b/Tests/ShadowtypeTests/PowerPolicyTests.swift
@@ -1,0 +1,135 @@
+// PowerPolicy / InferenceEngine thread sizing — the "stay invisible" pair. Shadowtype is a background
+// menu-bar app that runs inference on every typing pause, so two things decide whether the user
+// notices it: how many CPU threads llama spins against their foreground work, and whether anything
+// backs off when the Mac is hot or in Low Power Mode. Both decisions are pure/static precisely so
+// they can be pinned here, on a cool Mac of any core count.
+import XCTest
+@testable import Shadowtype
+
+final class PowerPolicyTests: XCTestCase {
+    // A representative "user configured the defaults" baseline: 50 ms trigger delay, the .extraLong
+    // token ceiling, the default 1024-token context.
+    private let base = PowerPolicy.Settings(debounce: 0.05, maxTokens: 40, maxContextTokens: 1024)
+
+    private let allStates: [ProcessInfo.ThermalState] = [.nominal, .fair, .serious, .critical]
+
+    // MARK: - Tier mapping
+
+    // `.fair` is where a laptop sits whenever it is doing real work; treating it as pressure would
+    // mean throttling essentially always, so only `.serious`/`.critical` (or Low Power Mode) count.
+    func testTierIgnoresNominalAndFairWithoutLowPower() {
+        XCTAssertEqual(PowerPolicy.tier(thermalState: .nominal, lowPower: false), .nominal)
+        XCTAssertEqual(PowerPolicy.tier(thermalState: .fair, lowPower: false), .nominal)
+    }
+
+    func testTierEscalatesWithThermalState() {
+        XCTAssertEqual(PowerPolicy.tier(thermalState: .serious, lowPower: false), .moderate)
+        XCTAssertEqual(PowerPolicy.tier(thermalState: .critical, lowPower: false), .heavy)
+    }
+
+    // Low Power Mode is an explicit user request to spend less energy: it throttles on its own...
+    func testLowPowerModeAloneThrottles() {
+        XCTAssertEqual(PowerPolicy.tier(thermalState: .nominal, lowPower: true), .moderate)
+        XCTAssertEqual(PowerPolicy.tier(thermalState: .fair, lowPower: true), .moderate)
+    }
+
+    // ...and never SOFTENS a hotter state (a critical Mac in Low Power Mode is still critical).
+    func testLowPowerModeNeverSoftensThermalState() {
+        XCTAssertEqual(PowerPolicy.tier(thermalState: .critical, lowPower: true), .heavy)
+        XCTAssertEqual(PowerPolicy.tier(thermalState: .serious, lowPower: true), .moderate)
+    }
+
+    // MARK: - Adjusted values
+
+    func testNoPressureLeavesSettingsUntouched() {
+        XCTAssertEqual(PowerPolicy.adjust(base, thermalState: .nominal, lowPower: false), base)
+        XCTAssertEqual(PowerPolicy.adjust(base, thermalState: .fair, lowPower: false), base)
+    }
+
+    func testModeratePressureLengthensPauseAndShortensGeneration() {
+        let out = PowerPolicy.adjust(base, thermalState: .serious, lowPower: false)
+        XCTAssertEqual(out.debounce, 0.10, accuracy: 1e-9)   // 2x the configured delay
+        XCTAssertEqual(out.maxTokens, 12)
+        XCTAssertEqual(out.maxContextTokens, 1024)           // already at/below the cap
+    }
+
+    func testHeavyPressureThrottlesFurtherThanModerate() {
+        let moderate = PowerPolicy.adjust(base, thermalState: .serious, lowPower: false)
+        let heavy = PowerPolicy.adjust(base, thermalState: .critical, lowPower: false)
+        XCTAssertGreaterThan(heavy.debounce, moderate.debounce)
+        XCTAssertLessThan(heavy.maxTokens, moderate.maxTokens)
+        XCTAssertLessThan(heavy.maxContextTokens, moderate.maxContextTokens)
+    }
+
+    // MARK: - Invariants
+
+    // The user's own settings are the CEILING: adaptation may only make the app lighter. If this ever
+    // inverts, a throttle would speed the app up (or lengthen generation) behind the user's back.
+    func testAdaptationIsNeverHeavierThanConfigured() {
+        // A spread of plausible user settings, including a deliberately slow/small one.
+        let bases = [
+            base,
+            PowerPolicy.Settings(debounce: 0.04, maxTokens: 8, maxContextTokens: 256),
+            PowerPolicy.Settings(debounce: 0.4, maxTokens: 16, maxContextTokens: 4096),
+        ]
+        for b in bases {
+            for state in allStates {
+                for lowPower in [false, true] {
+                    let out = PowerPolicy.adjust(b, thermalState: state, lowPower: lowPower)
+                    XCTAssertGreaterThanOrEqual(out.debounce, b.debounce, "\(state) lowPower=\(lowPower)")
+                    XCTAssertLessThanOrEqual(out.maxTokens, b.maxTokens, "\(state) lowPower=\(lowPower)")
+                    XCTAssertLessThanOrEqual(out.maxContextTokens, b.maxContextTokens,
+                                             "\(state) lowPower=\(lowPower)")
+                }
+            }
+        }
+    }
+
+    // A user who already asked for a small budget keeps it — the caps clamp DOWN, they never raise.
+    func testAlreadyLightSettingsAreLeftAlone() {
+        let light = PowerPolicy.Settings(debounce: 0.4, maxTokens: 8, maxContextTokens: 256)
+        let out = PowerPolicy.adjust(light, thermalState: .critical, lowPower: true)
+        XCTAssertEqual(out.maxTokens, 8)
+        XCTAssertEqual(out.maxContextTokens, 256)
+    }
+
+    // The debounce cap bounds the STRETCH, but must not shorten a longer configured delay: a user with
+    // a 2 s pause stays at 2 s under critical rather than being sped up to the 1 s cap.
+    func testDebounceCapNeverShortensALongConfiguredDelay() {
+        let slow = PowerPolicy.Settings(debounce: 2.0, maxTokens: 40, maxContextTokens: 1024)
+        XCTAssertEqual(PowerPolicy.adjust(slow, thermalState: .critical, lowPower: false).debounce,
+                       2.0, accuracy: 1e-9)
+    }
+
+    // ...and it does bound the stretch for in-range settings (0.4 * 3 would be 1.2 s).
+    func testDebounceStretchIsCapped() {
+        let slider = PowerPolicy.Settings(debounce: 0.4, maxTokens: 40, maxContextTokens: 1024)
+        XCTAssertEqual(PowerPolicy.adjust(slider, thermalState: .critical, lowPower: false).debounce,
+                       1.0, accuracy: 1e-9)
+    }
+
+    // Throttling must never amount to switching suggestions off — a silently dead product is worse
+    // than a slower one. Every tier still leaves a usable generation and prompt budget.
+    func testThrottlingNeverDisablesSuggestions() {
+        for state in allStates {
+            for lowPower in [false, true] {
+                let out = PowerPolicy.adjust(base, thermalState: state, lowPower: lowPower)
+                XCTAssertGreaterThanOrEqual(out.maxTokens, 8, "\(state) lowPower=\(lowPower)")
+                XCTAssertGreaterThanOrEqual(out.maxContextTokens, 512, "\(state) lowPower=\(lowPower)")
+                XCTAssertLessThanOrEqual(out.debounce, 1.0, "\(state) lowPower=\(lowPower)")
+            }
+        }
+    }
+
+    // Every shipping CompletionLength preset must survive the policy: the throttled ceiling is still a
+    // value the pipeline already ships (>= the .short preset's 8), so no preset can be squeezed to zero.
+    func testEveryCompletionLengthPresetStaysUsableUnderPressure() {
+        for length in CompletionLength.allCases {
+            let configured = PowerPolicy.Settings(debounce: 0.05,
+                                                  maxTokens: length.maxTokens,
+                                                  maxContextTokens: 1024)
+            let out = PowerPolicy.adjust(configured, thermalState: .critical, lowPower: true)
+            XCTAssertGreaterThanOrEqual(out.maxTokens, min(length.maxTokens, 8), "\(length)")
+        }
+    }
+}

--- a/Tests/ShadowtypeTests/PromptHeadStabilityTests.swift
+++ b/Tests/ShadowtypeTests/PromptHeadStabilityTests.swift
@@ -1,0 +1,87 @@
+// PromptHeadStabilityTests — the end-to-end guard on the invariant the whole prompt/KV design rests on.
+//
+// The engine reuses KV by longest-common-PREFIX (InferenceEngine.reuseLength). Every context block —
+// instruction, style, clipboard, screen OCR, post-caret — is assembled IN FRONT of the caret text, so if
+// any of them changes while the user types, the streams diverge at the first token and each fire pays a
+// full cold prefill instead of the warm path. The individual pieces have their own unit tests
+// (anchoredTail, trimToWindow, the de-drafted OCR block); this file asserts the property that actually
+// matters, on the WHOLE assembled prompt, with every block switched on at once.
+//
+// It exists because the composition regressed while each piece stayed correct: anchoredTail pins the
+// prefix window's START, but its LENGTH grows a byte per keystroke, and while the prefix shared one
+// allocation pass with the context blocks that byte came out of the OCR block's budget — re-cutting a
+// block that sits in front of the prefix, on every keystroke. Measured 120 distinct heads across 120
+// keystrokes: the anchoring was fully defeated, and no existing test could see it.
+import XCTest
+@testable import Shadowtype
+
+final class PromptHeadStabilityTests: XCTestCase {
+
+    private func head(of prompt: String) -> String {
+        if let r = prompt.range(of: "\n\nText (in English):\n") ?? prompt.range(of: "\n\nText:\n") {
+            return String(prompt[..<r.upperBound])
+        }
+        return "<no-marker>"
+    }
+
+    /// Every block on (paid instruction + style + screen OCR + post-caret + language steer), budget
+    /// binding, draft growing one character per keystroke: the head must not move.
+    func testHeadIsByteStableWithEveryContextBlockPresent() throws {
+        let ocr = (1...40).map { "Screen line \($0) of surrounding conversation context." }.joined(separator: "\n")
+        let suffix = "\n\nThis paragraph already follows the caret and must not be duplicated."
+        let base = String(repeating: "The quick brown fox jumps over the lazy dog. ", count: 60)
+
+        var heads = Set<String>()
+        var prompts: [String] = []
+        for i in 0..<120 {
+            let p = CompletionCoordinator.assemblePrompt(
+                prefix: base + String(repeating: "x", count: i), isLicensed: true,
+                instruction: "Reply in a friendly tone", styleHint: "favors: concise; direct",
+                styleEnabled: true, clipboard: nil, clipboardEnabled: false,
+                ocr: ocr, ocrEnabled: true, postCaret: suffix,
+                steerLanguageName: "English", totalChars: 3520)
+            prompts.append(p.prompt)
+            heads.insert(head(of: p.prompt))
+        }
+        // Guard against passing vacuously: a run where the budget dropped EVERY block would have no
+        // `Text:` marker and a constant "<no-marker>" head, which is stable and worthless. The head must
+        // really be carrying context.
+        let sample = try XCTUnwrap(prompts.last)
+        XCTAssertTrue(sample.hasPrefix("Context:\n"), "no context survived — the stability check is vacuous")
+        XCTAssertTrue(sample.contains("Screen line"), "screen context was dropped entirely")
+        XCTAssertTrue(sample.contains("follows the caret"), "post-caret block was dropped entirely")
+        // The head may change when the prefix window RE-ANCHORS (once per anchor step, so at most once or
+        // twice across a 120-byte burst) — that is the design. What must never happen is the regression
+        // this file was written for: one distinct head per keystroke.
+        XCTAssertLessThanOrEqual(heads.count, 2,
+                                 "prompt head mutated \(heads.count)x across 120 keystrokes — KV reuse is defeated")
+
+        // The stronger form of the same property: each prompt is a strict EXTENSION of the previous one,
+        // which is exactly what reuseLength needs. The prefix window re-anchors in steps, so a small
+        // number of non-extension steps is expected; one per anchor step, not one per keystroke.
+        let nonExtensions = (1..<prompts.count).filter { !prompts[$0].hasPrefix(prompts[$0 - 1]) }.count
+        XCTAssertLessThanOrEqual(nonExtensions, 3, "expected re-anchor steps only, got \(nonExtensions)")
+    }
+
+    /// The Free default (no licence, screen context off) must still be the bare prefix — no framing, no
+    /// wasted cap — and equally stable.
+    func testFreeDefaultStaysBarePrefixAndStable() {
+        let base = String(repeating: "words in a draft ", count: 40)
+        var heads = Set<String>()
+        for i in 0..<60 {
+            let draft = base + String(repeating: "y", count: i)
+            let p = CompletionCoordinator.assemblePrompt(
+                prefix: draft, isLicensed: false,
+                instruction: "ignored when unlicensed", styleHint: "ignored", styleEnabled: true,
+                clipboard: "ignored", clipboardEnabled: true, ocr: nil, ocrEnabled: false,
+                postCaret: nil, steerLanguageName: nil, totalChars: 3520)
+            XCTAssertFalse(p.prompt.contains("Context:\n"), "unlicensed context leaked into the prompt")
+            // Compared against the trailing-whitespace-trimmed draft: assemblePrompt deliberately drops a
+            // dangling space so the base model predicts the next space-prefixed word.
+            XCTAssertTrue(draft.trimmingCharacters(in: .whitespaces).hasSuffix(p.prompt),
+                          "free path must be a plain tail of the draft")
+            heads.insert(String(p.prompt.prefix(32)))
+        }
+        XCTAssertLessThanOrEqual(heads.count, 2, "free-path head slid \(heads.count) times")
+    }
+}

--- a/Tests/ShadowtypeTests/RewriteActionTests.swift
+++ b/Tests/ShadowtypeTests/RewriteActionTests.swift
@@ -102,6 +102,33 @@ final class RewriteActionTests: XCTestCase {
         }
     }
 
+    // ⌘R "redo" re-issues the SAME selection + action, so the prompt is identical and the sampler is
+    // rebuilt per generate(); with a fixed seed the redo returned byte-identical text (a silent no-op).
+    // Successive parameter builds must therefore differ in seed — and in seed only.
+    func testRewriteParamsVarySeedPerInvocation() {
+        let first = SamplingParams.rewriteDefaults()
+        let second = SamplingParams.rewriteDefaults()
+        XCTAssertNotEqual(first.seed, second.seed, "redo must sample from a different seed")
+
+        var normalized = second
+        normalized.seed = first.seed
+        XCTAssertEqual(first, normalized, "only the seed may vary between rewrite invocations")
+
+        // The rest of the rewrite chain: ghost sampling with the ghost stop policy OFF.
+        XCTAssertEqual(first.temperature, SamplingParams.ghostDefaults.temperature)
+        XCTAssertFalse(first.useEngineStopPolicy)
+        XCTAssertEqual(first.stopStrings, ["\nText:", "\nText (", "\nRewritten:"])
+    }
+
+    // The ghost path must stay deterministic: same prompt → same suggestion, or inline ghost text
+    // flickers between keystrokes. Varying the rewrite seed must not have leaked into ghostDefaults.
+    func testGhostDefaultsKeepFixedSeed() {
+        XCTAssertEqual(SamplingParams.ghostDefaults.seed, 0xACE1)
+        _ = SamplingParams.rewriteDefaults()
+        XCTAssertEqual(SamplingParams.ghostDefaults.seed, 0xACE1,
+                       "a rewrite must not mutate the ghost seed")
+    }
+
     // The localized halt markers (`Text (in Spanish):`, `Rewritten (in Spanish):`) must cut runaway
     // just like the plain ones — otherwise the model's next fresh exemplar block leaks into the result.
     func testCleanOutputStopsAtLocalizedTextMarker() {

--- a/Tests/ShadowtypeTests/SamplingParamsTests.swift
+++ b/Tests/ShadowtypeTests/SamplingParamsTests.swift
@@ -101,6 +101,35 @@ final class SamplingParamsTests: XCTestCase {
                        "FIM payload must round-trip — the engine reads .prefix + .suffix directly")
     }
 
+    // --- Repetition-penalty window priming (InferenceEngine.penaltyPrimeTokens) ---------------
+    // The bug: llama_sampler_accept only ever saw tokens the CALL generated, so with maxTokens 16-24
+    // the 64-token penalty window never held a single PROMPT token — nothing discouraged the ghost
+    // from echoing what the user had just typed, while short-range repetition inside the completion
+    // was still penalised.
+
+    func testPenaltyPrimeIsTheLastNPromptTokensInOrder() {
+        let prompt = (1...200).map { Int32($0) }
+        let primed = Array(InferenceEngine.penaltyPrimeTokens(prompt: prompt, lastN: 64))
+        XCTAssertEqual(primed.count, 64)
+        XCTAssertEqual(primed.first, 137)
+        XCTAssertEqual(primed.last, 200,
+                       "the ring buffer evicts from the front — the most recent prompt token must be accepted LAST")
+    }
+
+    func testPenaltyPrimeHandlesShortPrompt() {
+        let prompt: [Int32] = [7, 8, 9]
+        XCTAssertEqual(Array(InferenceEngine.penaltyPrimeTokens(prompt: prompt, lastN: 64)), prompt)
+    }
+
+    func testPenaltyPrimeEmptyWithoutAWindow() {
+        // repeatPenaltyLastN == 0 is a documented no-op inside llama.cpp's penalties sampler; priming
+        // it would be pointless work. API defaults use 0 — clients bring their own penalty.
+        XCTAssertTrue(InferenceEngine.penaltyPrimeTokens(prompt: [1, 2, 3], lastN: 0).isEmpty)
+        XCTAssertEqual(SamplingParams.apiDefaults.repeatPenaltyLastN, 0)
+        XCTAssertEqual(SamplingParams.ghostDefaults.repeatPenaltyLastN, 64,
+                       "ghost keeps a penalty window, so the prompt tail is what gets replayed into it")
+    }
+
     func testFIMRequestEquality() {
         let a = FIMRequest(prefix: "foo", suffix: "bar")
         let b = FIMRequest(prefix: "foo", suffix: "bar")

--- a/Tests/ShadowtypeTests/SentenceBoundaryTests.swift
+++ b/Tests/ShadowtypeTests/SentenceBoundaryTests.swift
@@ -53,6 +53,38 @@ final class SentenceBoundaryTests: XCTestCase {
         XCTAssertFalse(stop(",", "hello", " "))     // ASCII comma
     }
 
+    // MARK: - Space-less scripts (word boundaries)
+    // The ghost decode loop's word flush and word cap keyed off whitespace alone, so for these
+    // languages nothing ever streamed and wordCount stayed 0 — maxWords and stopAtSentenceAfterWords
+    // were both unreachable and the completion ran to maxTokens as one all-or-nothing event.
+
+    func testSpacelessScriptsAreWordBoundaries() {
+        for c in "資料準備日本語" { XCTAssertTrue(SentenceBoundary.isSpacelessScript(c), "CJK: \(c)") }
+        for c in "もうひらがな" { XCTAssertTrue(SentenceBoundary.isSpacelessScript(c), "hiragana: \(c)") }
+        for c in "カタカナ" { XCTAssertTrue(SentenceBoundary.isSpacelessScript(c), "katakana: \(c)") }
+        for c in "สวัสดีครับ" { XCTAssertTrue(SentenceBoundary.isSpacelessScript(c), "Thai: \(c)") }
+        for c in "ຂໍ້ຄວາມ" { XCTAssertTrue(SentenceBoundary.isSpacelessScript(c), "Lao: \(c)") }
+        for c in "សួស្តី" { XCTAssertTrue(SentenceBoundary.isSpacelessScript(c), "Khmer: \(c)") }
+        XCTAssertTrue(SentenceBoundary.isSpacelessScript("𠀋"), "CJK Extension B (astral plane)")
+    }
+
+    func testSpacedScriptsAreNotWordBoundaries() {
+        for c in "hello wörld" { XCTAssertFalse(SentenceBoundary.isSpacelessScript(c), "Latin: \(c)") }
+        for c in "привет" { XCTAssertFalse(SentenceBoundary.isSpacelessScript(c), "Cyrillic: \(c)") }
+        for c in "مرحبا" { XCTAssertFalse(SentenceBoundary.isSpacelessScript(c), "Arabic: \(c)") }
+        // Korean DOES space its words, so the whitespace rule already covers it — treating each
+        // syllable block as a word would cap a Hangul completion at maxWords syllables.
+        for c in "안녕하세요" { XCTAssertFalse(SentenceBoundary.isSpacelessScript(c), "Hangul: \(c)") }
+    }
+
+    func testCJKPunctuationIsNotAWordCharacter() {
+        // U+3000–U+303F is punctuation, not script: 。 and 、 must stay with the terminator policy
+        // rather than being flushed as a word of their own.
+        XCTAssertFalse(SentenceBoundary.isSpacelessScript("。"))
+        XCTAssertFalse(SentenceBoundary.isSpacelessScript("、"))
+        XCTAssertFalse(SentenceBoundary.isSpacelessScript("！"))
+    }
+
     func testFirstStopIndexScansWithContext() {
         // "Mr. Smith arrived." — the first period (Mr.) is not a stop; the last one is.
         let piece = "Mr. Smith arrived."

--- a/Tests/ShadowtypeTests/ShellPromptAssemblyTests.swift
+++ b/Tests/ShadowtypeTests/ShellPromptAssemblyTests.swift
@@ -65,6 +65,70 @@ final class ShellPromptAssemblyTests: XCTestCase {
         XCTAssertEqual(CompletionCoordinator.shellCurrentLine("git pu"), "git pu")
     }
 
+    // MARK: - Prompt chrome on the CURRENT line
+    //
+    // Every test above hands the assembler a pre-cleaned stem ("git pu"), which baked in the assumption
+    // that the current line arrives chrome-free. In a real terminal it does not: the AX prefix ends with
+    // the live PS1 — the very thing isShellPromptLine matched to enter shell mode.
+
+    func testShellTypedCommandStripsPromptChrome() {
+        XCTAssertEqual(CompletionCoordinator.shellTypedCommand("~ $ cd proj\ndario@mac ~/proj % git pu"),
+                       "git pu")
+        // Trailing space is PRESERVED: a typed `git ` must complete to `status`, not ` status`.
+        XCTAssertEqual(CompletionCoordinator.shellTypedCommand("~/proj $ git "), "git ")
+        // Chrome only — nothing typed yet.
+        XCTAssertEqual(CompletionCoordinator.shellTypedCommand("~/proj $ "), "")
+        // No sigil (terminals that expose only the typed text) → the raw line, unchanged behaviour.
+        XCTAssertEqual(CompletionCoordinator.shellTypedCommand("line1\ngit pu"), "git pu")
+    }
+
+    // The continuation line must stay command-shaped. With the chrome it read
+    // `$ dario@mac ~/proj % git pu` — not a command, and repeating the stem the exemplars already end on.
+    func testAssembleShellPromptStripsChromeFromTheTypedTail() {
+        let buf = """
+        ~ $ cd proj
+        ~/proj $ git status
+        dario@mac ~/proj % git pu
+        """
+        let out = CompletionCoordinator.assembleShellPrompt(
+            prefix: "~ $ cd proj\ndario@mac ~/proj % git pu", terminalBuffer: buf)
+        XCTAssertTrue(out.hasSuffix("$ git pu"))
+        XCTAssertFalse(out.contains("$ dario@mac"))
+        // The exemplar equal to the typed stem is dropped, so the stem appears exactly once.
+        XCTAssertEqual(out.components(separatedBy: "$ git pu").count - 1, 1)
+    }
+
+    // Redaction was applied to the exemplars but not to the typed tail, so a secret on the line the user
+    // is typing RIGHT NOW — the one most worth withholding — went to the model verbatim.
+    func testAssembleShellPromptRedactsTheTypedTail() {
+        let out = CompletionCoordinator.assembleShellPrompt(
+            prefix: "~ $ export AWS_SECRET_ACCESS_KEY=abc123", terminalBuffer: "~ $ ls")
+        XCTAssertFalse(out.contains("abc123"))
+        XCTAssertTrue(out.hasSuffix("$ export AWS_SECRET_ACCESS_KEY=•••"))
+    }
+
+    // The zero-hallucination fast path compares the stem against chrome-STRIPPED history commands, so a
+    // chrome-laden stem could never match anything and the path was dead in a real terminal.
+    func testHistoryPrefixMatchNeedsTheChromeStrippedStem() {
+        let buf = "~ $ git status\n~ $ docker compose up -d\n~/proj % doc"
+        let prefix = "~ $ git status\n~/proj % doc"
+        XCTAssertNil(ShellHistory.prefixMatch(currentLine: CompletionCoordinator.shellCurrentLine(prefix),
+                                              buffer: buf))
+        XCTAssertEqual(ShellHistory.prefixMatch(currentLine: CompletionCoordinator.shellTypedCommand(prefix),
+                                                buffer: buf),
+                       "ker compose up -d")
+    }
+
+    // The destructive-command guard tokenizes the JOINED line: with the chrome its first token was
+    // `dario@mac`, never `rm`, so the whole denylist was bypassed at a real shell prompt.
+    func testDangerGuardOnlySeesTheCommandOnceChromeIsStripped() {
+        let prefix = "~ $ ls\ndario@mac ~/proj % rm -rf "
+        XCTAssertFalse(ShellCommandGuard.isDangerous(
+            fullCommand: CompletionCoordinator.shellCurrentLine(prefix) + "/"))
+        XCTAssertTrue(ShellCommandGuard.isDangerous(
+            fullCommand: CompletionCoordinator.shellTypedCommand(prefix) + "/"))
+    }
+
     func testTruncatedAtNewlineKeepsOneLine() {
         XCTAssertEqual(CompletionCoordinator.truncatedAtNewline("sh\nmore"), "sh")
         XCTAssertEqual(CompletionCoordinator.truncatedAtNewline("\n\npush"), "push")

--- a/Tests/ShadowtypeTests/StyleProfileTests.swift
+++ b/Tests/ShadowtypeTests/StyleProfileTests.swift
@@ -18,6 +18,23 @@ final class StyleProfileTests: XCTestCase {
         StyleProfile(storeURL: url, secret: secret)
     }
 
+    // styleHint() stays silent below `minInputsForHint` accepts (a profile built from two sentences is
+    // noise), so every test that asserts on hint CONTENT has to train past that floor first.
+    private func train(_ p: StyleProfile, _ phrases: [String], bundleId: String? = nil,
+                       rounds: Int = StyleProfile.minInputsForHint) {
+        for _ in 0..<rounds {
+            for phrase in phrases { p.recordAccepted(phrase, bundleId: bundleId) }
+        }
+    }
+
+    private static let hintPrefix = "User writing style — favors: "
+
+    // The hint's items, so tests can assert on what was emitted rather than on substrings of the line.
+    private func hintItems(_ hint: String) -> [String] {
+        guard hint.hasPrefix(Self.hintPrefix) else { return [] }
+        return String(hint.dropFirst(Self.hintPrefix.count)).components(separatedBy: "; ")
+    }
+
     // MARK: - Empty profile
 
     func testEmptyProfileHintIsNil() {
@@ -34,8 +51,7 @@ final class StyleProfileTests: XCTestCase {
 
     func testRecordingThenHintIsNonNil() {
         let p = profile(tempURL())
-        p.recordAccepted("Thanks so much for reaching out")
-        p.recordAccepted("Happy to help with that")
+        train(p, ["Thanks so much for reaching out", "Happy to help with that"])
         let hint = p.styleHint(maxChars: 300)
         XCTAssertNotNil(hint)
         // The hint surfaces the user's own phrasing.
@@ -49,6 +65,26 @@ final class StyleProfileTests: XCTestCase {
         XCTAssertNil(p.styleHint(maxChars: 200))
     }
 
+    // MARK: - Evidence floor: a tiny profile describes nobody
+
+    func testTinyCorpusYieldsNoHint() {
+        // Three sentences is not a writing style, and the hint it would produce costs prompt budget that
+        // the real context needs — stay silent until there is enough material.
+        let p = profile(tempURL())
+        p.recordAccepted("kindly regards always")
+        p.recordAccepted("looking forward to hearing back")
+        p.recordAccepted("happy to help with that")
+        XCTAssertNil(p.styleHint(maxChars: 400), "3 inputs must not produce a style hint")
+    }
+
+    func testHintAppearsExactlyAtTheEvidenceFloor() {
+        let p = profile(tempURL())
+        for _ in 0..<(StyleProfile.minInputsForHint - 1) { p.recordAccepted("kindly regards always") }
+        XCTAssertNil(p.styleHint(maxChars: 400), "below the floor the hint must stay nil")
+        p.recordAccepted("kindly regards always")
+        XCTAssertNotNil(p.styleHint(maxChars: 400), "at the floor the hint must appear")
+    }
+
     // MARK: - Vocabulary-only: no verbatim content / digit bleed (FR-CTX-3 anti-regurgitation)
 
     func testHintDoesNotSurfaceVerbatimPhrase() {
@@ -56,7 +92,7 @@ final class StyleProfileTests: XCTestCase {
         // otherwise the base model parrots it across unrelated apps (Notes story -> Slack message).
         let p = profile(tempURL())
         let phrase = "una princesa vive en castillo"     // 5 words, learned, but never emitted whole
-        for _ in 0..<3 { p.recordAccepted(phrase) }
+        train(p, [phrase])
         let hint = p.styleHint(maxChars: 400)
         XCTAssertNotNil(hint)
         XCTAssertFalse(hint!.contains(phrase), "verbatim phrase leaked into the style hint")
@@ -66,17 +102,70 @@ final class StyleProfileTests: XCTestCase {
     func testHintExcludesDigitNGrams() {
         // Stray numerals (the old "2 …" garbage) are noise, not style — never surface them.
         let p = profile(tempURL())
-        for _ in 0..<3 { p.recordAccepted("2 y el baile feliz") }
+        train(p, ["2 y el baile feliz"])
         let hint = p.styleHint(maxChars: 400)
         XCTAssertNotNil(hint)
         XCTAssertFalse(hint!.contains("2"), "digit n-gram leaked into the style hint")
     }
 
     func testLongPhrasingNotLearned() {
-        // Above maxPhraseWords the input is content, not voice — ignored entirely.
+        // Above maxPhraseWords the input is content, not voice — ignored entirely. Fed well past the
+        // evidence floor so a nil hint can only mean "never learned", not "not enough inputs yet".
         let p = profile(tempURL())
-        p.recordAccepted("this is a long sentence with definitely more than six words total")
+        train(p, ["this is a long sentence with definitely more than six words total"])
         XCTAssertNil(p.styleHint(maxChars: 300))
+    }
+
+    // MARK: - Distinctiveness: function words are not a writing style
+
+    func testOrdinaryEnglishDoesNotProduceAStopwordHint() {
+        // Ranked by raw frequency this corpus yields exactly "of the; the; and ..." — a line of English
+        // glue that says nothing about the user, outranks the real screen context in the prompt budget,
+        // and reads to a base model as document content to imitate. Every emitted item must carry at
+        // least one content word.
+        let p = profile(tempURL())
+        train(p, [
+            "the state of the art",
+            "one of the best",
+            "part of the team",
+            "most of the time",
+            "the end of the day",
+            "the rest of the file",
+        ])
+        let hint = p.styleHint(maxChars: 400)
+        XCTAssertNotNil(hint)
+        let items = hintItems(hint!)
+        XCTAssertFalse(items.isEmpty, "could not parse hint items from: \(hint!)")
+        for item in items {
+            XCTAssertGreaterThan(StyleProfile.contentTokenCount(item), 0,
+                                 "pure-stopword item '\(item)' leaked into the style hint")
+        }
+        for junk in ["of the", "the", "and", "that", "in the", "to the"] {
+            XCTAssertFalse(items.contains(junk), "'\(junk)' leaked into the style hint")
+        }
+    }
+
+    func testDistinctiveVocabularyOutranksMoreFrequentGlue() {
+        // The filler is fed MORE often than the distinctive phrasing on purpose: raw frequency would put
+        // "is one" first, distinctiveness puts the two-content-word bigram first.
+        let p = profile(tempURL())
+        train(p, ["it is one of the"], rounds: StyleProfile.minInputsForHint * 2)
+        train(p, ["kubernetes operator reconciled the pods"])
+        let hint = p.styleHint(maxChars: 400)
+        XCTAssertNotNil(hint)
+        let items = hintItems(hint!)
+        XCTAssertEqual(items.first, "kubernetes operator",
+                       "distinctive vocabulary should lead the hint, got: \(items)")
+        XCTAssertTrue(items.contains("kubernetes"), "distinctive words must still surface: \(items)")
+    }
+
+    func testContentTokenCountIgnoresFunctionWords() {
+        XCTAssertEqual(StyleProfile.contentTokenCount("the"), 0)
+        XCTAssertEqual(StyleProfile.contentTokenCount("of the"), 0)
+        XCTAssertEqual(StyleProfile.contentTokenCount("de la"), 0)      // same trap in Spanish
+        XCTAssertEqual(StyleProfile.contentTokenCount("the meeting"), 1)
+        XCTAssertEqual(StyleProfile.contentTokenCount("una princesa"), 1)
+        XCTAssertEqual(StyleProfile.contentTokenCount("baile feliz"), 2)
     }
 
     // MARK: - maxChars respected
@@ -95,7 +184,7 @@ final class StyleProfileTests: XCTestCase {
 
     func testHintNilWhenMaxCharsTooSmallForPrefix() {
         let p = profile(tempURL())
-        p.recordAccepted("hello there friend")
+        train(p, ["hello there friend"])   // past the evidence floor: nil must be the cap's doing
         XCTAssertNil(p.styleHint(maxChars: 5)) // smaller than the leading label
         XCTAssertNil(p.styleHint(maxChars: 0))
     }
@@ -106,8 +195,9 @@ final class StyleProfileTests: XCTestCase {
         let url = tempURL()
         do {
             let p = profile(url)
-            p.recordAccepted("kindly let me know if you have questions")
-            p.recordAccepted("looking forward to hearing back")
+            // Both phrasings are <= maxPhraseWords so they are actually learned (the longer variant of
+            // the first one used to be silently dropped, making this test assert on one phrase only).
+            train(p, ["kindly let me know", "looking forward to hearing back"])
             XCTAssertNotNil(p.styleHint(maxChars: 300))
             p.flushPendingWrites()   // writes are async; flush before reopening from disk
         }
@@ -142,7 +232,7 @@ final class StyleProfileTests: XCTestCase {
     func testWipeEmptiesAndRemovesFile() throws {
         let url = tempURL()
         let p = profile(url)
-        p.recordAccepted("some learned phrasing here")
+        train(p, ["some learned phrasing here"])
         p.flushPendingWrites()
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
         XCTAssertNotNil(p.styleHint(maxChars: 200))
@@ -178,6 +268,9 @@ final class StyleProfileTests: XCTestCase {
         let p = profile(tempURL())
         p.recordAccepted("kindly regards", bundleId: "com.apple.mail")
         p.recordAccepted("lol yeah", bundleId: "com.tinyspeck.slackmacgap")
+        // The evidence floor is on the MERGED total, so neither app alone has to clear it.
+        train(p, ["kindly regards"], bundleId: "com.apple.mail", rounds: 4)
+        train(p, ["lol yeah"], bundleId: "com.tinyspeck.slackmacgap", rounds: 4)
         let hint = p.styleHint(maxChars: 400)
         XCTAssertNotNil(hint)
         // Both apps' vocabulary contributes to the single merged hint.
@@ -187,11 +280,12 @@ final class StyleProfileTests: XCTestCase {
 
     func testDeleteAppRemovesOnlyThatApp() {
         let p = profile(tempURL())
-        p.recordAccepted("kindly regards always", bundleId: "com.apple.mail")
-        p.recordAccepted("lmao yeah totally", bundleId: "com.tinyspeck.slackmacgap")
+        train(p, ["kindly regards always"], bundleId: "com.apple.mail")
+        train(p, ["lmao yeah totally"], bundleId: "com.tinyspeck.slackmacgap")
         p.deleteApp(bundleId: "com.apple.mail")
         XCTAssertEqual(p.inputCount(forBundleId: "com.apple.mail"), 0)
-        XCTAssertEqual(p.inputCount(forBundleId: "com.tinyspeck.slackmacgap"), 1)
+        XCTAssertEqual(p.inputCount(forBundleId: "com.tinyspeck.slackmacgap"),
+                       StyleProfile.minInputsForHint)
         let hint = p.styleHint(maxChars: 400)
         XCTAssertNotNil(hint)
         XCTAssertFalse(hint!.contains("kindly"), "deleted app's vocabulary must not survive")
@@ -202,11 +296,11 @@ final class StyleProfileTests: XCTestCase {
         let url = tempURL()
         do {
             let p = profile(url)
-            p.recordAccepted("kindly let me know", bundleId: "com.apple.mail")
+            train(p, ["kindly let me know"], bundleId: "com.apple.mail")
             p.flushPendingWrites()
         }
         let reopened = profile(url)
-        XCTAssertEqual(reopened.inputCount(forBundleId: "com.apple.mail"), 1)
+        XCTAssertEqual(reopened.inputCount(forBundleId: "com.apple.mail"), StyleProfile.minInputsForHint)
         XCTAssertTrue(reopened.styleHint(maxChars: 300)?.contains("kindly") == true)
     }
 
@@ -214,15 +308,21 @@ final class StyleProfileTests: XCTestCase {
 
     func testMigratesOldGlobalProfile() throws {
         let url = tempURL()
-        // Write an OLD-shape record (top-level nGramCounts/recentPhrases, no perApp), sealed with the
-        // test secret exactly as the previous build would have.
-        let oldJSON = #"{"nGramCounts":{"kindly":3,"kindly regards":2},"recentPhrases":["kindly regards"]}"#
-        let sealed = try AES.GCM.seal(Data(oldJSON.utf8),
+        // Write an OLD-shape record (top-level nGramCounts/recentPhrases, no perApp AND no inputCount),
+        // sealed with the test secret exactly as the previous build would have.
+        let learned = StyleProfile.minInputsForHint + 1
+        let old: [String: Any] = [
+            "nGramCounts": ["kindly": learned, "regards": learned, "kindly regards": learned],
+            "recentPhrases": (0..<learned).map { "kindly regards \($0)" },
+        ]
+        let sealed = try AES.GCM.seal(JSONSerialization.data(withJSONObject: old),
                                       using: SymmetricKey(data: Self.testSecret)).combined!
         try sealed.write(to: url)
 
         let p = profile(url)   // first load migrates the old shape into `legacy`
         let hint = p.styleHint(maxChars: 300)
+        // The old shape has no inputCount; it is backfilled from recentPhrases so a long-trained profile
+        // isn't muted by the evidence floor on upgrade.
         XCTAssertNotNil(hint, "migrated old profile should still produce a hint")
         XCTAssertTrue(hint!.contains("kindly"))
         // New per-app learning coexists with the migrated legacy data.
@@ -237,7 +337,7 @@ final class StyleProfileTests: XCTestCase {
         let url = tempURL()
         do {
             let p = profile(url, secret: Self.testSecret)
-            p.recordAccepted("unreadable phrasing under this key")
+            train(p, ["unreadable phrasing under this key"])
             XCTAssertNotNil(p.styleHint(maxChars: 200))
             p.flushPendingWrites()
         }
@@ -246,7 +346,7 @@ final class StyleProfileTests: XCTestCase {
         XCTAssertNil(mismatched.styleHint(maxChars: 200))
 
         // And it can still learn + persist under its own key afterward (overwrites the file).
-        mismatched.recordAccepted("fresh start under the new key")
+        train(mismatched, ["fresh start under the new key"])
         XCTAssertNotNil(mismatched.styleHint(maxChars: 200))
         mismatched.flushPendingWrites()
         XCTAssertNotNil(profile(url, secret: Self.otherSecret).styleHint(maxChars: 200))

--- a/Tests/ShadowtypeTests/SuffixAfterCaretTests.swift
+++ b/Tests/ShadowtypeTests/SuffixAfterCaretTests.swift
@@ -1,0 +1,72 @@
+// EditContextTracker.suffixAfterCaret — the pure post-caret read. Until this existed the only thing
+// the product knew about text AFTER the caret was caretAtLineEnd()'s one-character peek, so a
+// completion could happily duplicate or contradict what sat three lines below. UTF-16 offsets, matching
+// kAXSelectedTextRange.
+import XCTest
+@testable import Shadowtype
+
+final class SuffixAfterCaretTests: XCTestCase {
+    func testTextAfterCaret() {
+        XCTAssertEqual(EditContextTracker.suffixAfterCaret("hello world", caret: 5, maxChars: 100),
+                       " world")
+    }
+
+    func testNilAtEndOfText() {
+        // Nothing follows → nil, not "": "no suffix" and "empty suffix" are the same fact and callers
+        // shouldn't have to special-case the empty string.
+        XCTAssertNil(EditContextTracker.suffixAfterCaret("hello", caret: 5, maxChars: 100))
+        XCTAssertNil(EditContextTracker.suffixAfterCaret("", caret: 0, maxChars: 100))
+    }
+
+    func testSpansNewlines() {
+        // The whole point: the caret can be at end-of-LINE and still have paragraphs below it.
+        let text = "Hi there,\n\nThanks for the update.\nBest,\n"
+        XCTAssertEqual(EditContextTracker.suffixAfterCaret(text, caret: 9, maxChars: 100),
+                       "\n\nThanks for the update.\nBest,\n")
+    }
+
+    func testLineEndDoesNotImplyNoSuffix() {
+        // caretAtLineEnd() is NOT an end-of-document test — the exact misconception the suffix read
+        // exists to fix. Both facts hold at once for the same caret.
+        let text = "line one\nline two"
+        XCTAssertTrue(EditContextTracker.isCaretAtLineEnd(text, caret: 8))
+        XCTAssertEqual(EditContextTracker.suffixAfterCaret(text, caret: 8, maxChars: 100), "\nline two")
+    }
+
+    func testCapsToMaxChars() {
+        XCTAssertEqual(EditContextTracker.suffixAfterCaret("abcdefghij", caret: 2, maxChars: 3), "cde")
+    }
+
+    func testZeroOrNegativeMaxCharsYieldsNil() {
+        XCTAssertNil(EditContextTracker.suffixAfterCaret("abc", caret: 0, maxChars: 0))
+        XCTAssertNil(EditContextTracker.suffixAfterCaret("abc", caret: 0, maxChars: -5))
+    }
+
+    func testClampsOutOfRangeCaret() {
+        XCTAssertNil(EditContextTracker.suffixAfterCaret("hi", caret: 99, maxChars: 10))  // past end
+        XCTAssertEqual(EditContextTracker.suffixAfterCaret("hi", caret: -1, maxChars: 10), "hi")
+    }
+
+    func testCapNeverSlicesASurrogatePair() {
+        // "a👋b": the emoji is TWO UTF-16 units. A cap landing between them must drop the dangling high
+        // surrogate rather than emit a lone one (which String repairs to U+FFFD).
+        let text = "a\u{1F44B}b"
+        XCTAssertEqual(EditContextTracker.suffixAfterCaret(text, caret: 0, maxChars: 2), "a")
+        XCTAssertEqual(EditContextTracker.suffixAfterCaret(text, caret: 0, maxChars: 3), "a\u{1F44B}")
+        // A cap of 1 that lands on the high surrogate alone has nothing left to return.
+        XCTAssertNil(EditContextTracker.suffixAfterCaret(text, caret: 1, maxChars: 1))
+    }
+
+    func testUncappedSuffixKeepsWholeEmoji() {
+        XCTAssertEqual(EditContextTracker.suffixAfterCaret("ok \u{1F44B}", caret: 3, maxChars: 400),
+                       "\u{1F44B}")
+    }
+
+    // The suffix is read at the same chokepoint as the prefix, so both sides get the NBSP fold that
+    // downstream boundary gates depend on (see normalizingSpaces / the Apple Mail bug).
+    func testNBSPFoldAppliesToSuffixShape() {
+        let raw = EditContextTracker.suffixAfterCaret("done\u{00A0}already", caret: 4, maxChars: 100)
+        XCTAssertEqual(raw, "\u{00A0}already")
+        XCTAssertEqual(raw.map(EditContextTracker.normalizingSpaces), " already")
+    }
+}

--- a/Tests/ShadowtypeTests/TypoGuardTests.swift
+++ b/Tests/ShadowtypeTests/TypoGuardTests.swift
@@ -34,8 +34,36 @@ final class TypoGuardTests: XCTestCase {
     // MARK: - Should NOT flag (conservative)
 
     func testNormalWordsPass() {
-        for w in ["hello", "completion", "keyboard", "rhythm", "because", "their", "world", "great"] {
+        // "lengths"/"strengths" carry a 5-consonant run, so they also pin the ORDER of the checks:
+        // the system-dictionary gate must run before signal 3, or they'd be flagged as typos.
+        for w in ["hello", "completion", "keyboard", "rhythm", "because", "their", "world", "great",
+                  "lengths", "strengths"] {
             XCTAssertFalse(guard_.looksLikeTypo(lastWord: w), "false positive on \(w)")
+        }
+    }
+
+    // Regression (the single largest quality bug the guard ever shipped): with only the tiny lexicon
+    // as an anchor, all 38 of these ordinary words were flagged as typos — every regular plural and
+    // dozens of everyday words sit one Damerau edit from a lexicon entry. Because the coordinator
+    // calls this on the trailing word of the prefix with holdBackOnTypos default ON, typing "in two
+    // weeks" or "I must" and pausing produced NO ghost, ever. The system dictionary now settles it
+    // before the edit-distance signal runs.
+    func testOrdinaryWordsNeverFlagged() {
+        let words = """
+            must made three those whole four hour tour line note host word near hear dear wear \
+            theme thin hers form code same weeks years days teams emails projects meetings things \
+            times places ways works makes looks takes uses
+            """.split(separator: " ").map(String.init)
+        XCTAssertEqual(words.count, 38)
+        for w in words {
+            XCTAssertFalse(guard_.looksLikeTypo(lastWord: w), "false positive on real word \(w)")
+        }
+    }
+
+    // ...and the dictionary gate must not cost us the real typos it sits in front of.
+    func testRealTyposStillFlaggedAfterDictionaryGate() {
+        for w in ["becuase", "thier", "helllo"] {
+            XCTAssertTrue(guard_.looksLikeTypo(lastWord: w), "real typo missed: \(w)")
         }
     }
 


### PR DESCRIPTION
A full audit of the inference core and the three tiers of fixes that came out of it. Four commits, each independently reviewable.

## Why

The core had drifted: two default settings contradicted each other, several quality gates were measuring the wrong thing (or nothing), and the UI made claims the code didn't honour. Most of these were invisible to the test suite — it stayed green through all of them.

## What changed

**Tier 1 — the prompt/KV path (`729fca8`)**
- `promptCharBudget` was a hardcoded 6000 bytes documented as "well inside the engine's 4096-token window", but `maxContextTokens` defaults to **1024**. The engine front-trims, so the tokenizer decapitated the `Context:` header, instruction, style, clipboard and OCR — and dropped BOS with them.
- The prefix declared its own full length as `maxChars` at top priority, so any draft past the budget consumed 100% of it and every context block silently vanished.
- Both truncation layers slid one unit per keystroke, so the prompt was never a strict extension and `reuseLength` returned 0 — a full cold prefill on **every fire**, in the long-prose case the warm path exists for. Both are now anchored.
- `unload()` left the token-byte table behind, so a model swap fed the next model the previous vocab's bytes — empty or garbled ghosts until relaunch, nothing logged.
- TypoGuard flagged **38/38** ordinary English words as typos (`weeks`, `must`, `three`, `form`…), suppressing the ghost on exactly the "paused after a word" state that is the primary trigger. Meanwhile `teh` — the example in its own doc comment — was never caught.

**Tier 2 — measurement and cost (`56d5c79`, `9540729`)**
- Confidence gating read the probability *after* top_k/top_p/temp, so a raw top-1 of 0.10 reported ~0.5. Both gates were decoration. Now computed from raw logits.
- The repetition penalty never saw the prompt, so nothing discouraged the ghost from echoing what the user just typed — the code compensated by *hiding* the finished suggestion.
- Screen context was re-cut every keystroke and leaked the user's own draft back into the prompt (the stale-capture `hasPrefix` case).
- `warmFocus` guaranteed a wasted prefill that the first real generation then queued *behind*.
- `fire()` ran four AX tree walks before three allocation-free gates that reject most pauses.
- Crash-on-quit (context freed on main under an in-flight decode), ghost starvation after API use, and the API silently inheriting the ghost's 1024-token window.
- Post-caret context: the model now knows what follows the caret. Mid-line default unchanged.

**Tier 3 — integrity and honesty (`a2a9d61`)**
- Downloads weren't resumable despite two comments saying so — a drop at 90% of 14 GB restarted from zero.
- "Verified by checksum" was mostly false: 9 of 11 entries ship `sha256: nil`, so the only check was the 4-byte GGUF magic. Now verified against the SHA-256 and size HF reports on the resolve redirect.
- `recommended()` returned the largest model that fits RAM — on a 32 GB Mac, the 18.6 GB 30B MoE, pre-selected as the first-run download. It cannot produce a first token inside the 400 ms deadline, so the ghost is dropped and the product reads as broken.
- Sharded-repo BYOM, RAM gate ignoring KV cache, dropped `llama-3.1-8b-instruct`, thermal/Low-Power backoff, and removal of three "Soon" controls with nothing behind them.

## Deliberately not shipped

The `n_threads` override. Its rationale was that llama sizes the pool from core count — it doesn't; `GGML_DEFAULT_N_THREADS` is a hard-coded 4. The override would have changed nothing on Pro/Max and silently halved base M-series Macs to 2 threads, unmeasured. Reverted with the reasoning recorded.

## Testing

**575 → 705 tests, 0 failures**, build clean.

Two regressions were caught by adversarial review rather than the suite, and both are now pinned by tests:
- Tier 2 silently undid Tier 1's KV stability — measured **120 distinct prompt heads across 120 keystrokes**, with every existing test passing. `PromptHeadStabilityTests` now covers the invariant end to end.
- Resume blobs were keyed by destination path alone, so two identically-named HF files from different repos shared one blob and the second import would have received the first's bytes.

## Risk

The download rewrite and the model-swap path can't be exercised by the test suite, and none of this has been run as a real app — a manual pass on a live download and a model swap is worth doing before this reaches stable users.