### PR TITLE
fix(context): capture the real window, stop serving another app's screen as context

### DIFF
--- a/Sources/Shadowtype/AXTextProbe.swift
+++ b/Sources/Shadowtype/AXTextProbe.swift
@@ -414,40 +414,51 @@ enum AXTextProbe {
         return best
     }
 
-    // Full visible text of a web area (the whole page), capped. Used as exact, permission-free,
+    // Full visible text of a web area (the whole page), capped to the recent tail. The messages nearest
+    // the composer carry the reply language and continuation context. Used as exact, permission-free,
     // synchronous context — strictly better fidelity than OCR where a web area exists. Best-effort
     // with three fallbacks; nil if none yields text.
     static func webAreaFullText(of webArea: AXUIElement, maxChars: Int = 20_000) -> String? {
         // (1) The element's own full text-marker range (the clean Chromium/WebKit way).
         if let range = copyParam(webArea, textMarkerRangeForUIElement, webArea),
            let s = copyParam(webArea, stringForTextMarkerRange, range) as? String, !s.isEmpty {
-            return String(s.prefix(maxChars))
+            return recentText(s, maxChars: maxChars)
         }
         // (2) Document start→end markers.
         if let docStart = copyValue(webArea, startTextMarker),
            let docEnd = copyValue(webArea, endTextMarker),
            let range = makeMarkerRange(webArea, start: docStart, end: docEnd),
            let s = copyParam(webArea, stringForTextMarkerRange, range) as? String, !s.isEmpty {
-            return String(s.prefix(maxChars))
+            return recentText(s, maxChars: maxChars)
         }
-        // (3) Fallback: bounded BFS gathering descendant text values.
+        // (3) Fallback: bounded tail-first walk gathering descendant text values.
         return gatherText(webArea, maxChars: maxChars)
     }
 
-    // Bounded BFS collecting kAXValue strings from descendants (AXStaticText etc.). Visit-capped so a
-    // huge page can't stall the hot path; stops once maxChars of text is gathered.
+    static func recentText(_ text: String, maxChars: Int) -> String {
+        String(text.suffix(maxChars))
+    }
+
+    // Bounded tail-first walk collecting kAXValue strings from descendants (AXStaticText etc.).
+    // Composer-adjacent text carries the reply language and continuation context; the character and
+    // visit caps keep the AX walk bounded.
     private static func gatherText(_ root: AXUIElement, maxChars: Int, visitCap: Int = 4000) -> String? {
-        var out = ""
+        var chunks: [String] = []
         var frontier = children(of: root)
         var visited = 0
-        while !frontier.isEmpty, out.count < maxChars, visited < visitCap {
-            let node = frontier.removeFirst()
+        var collected = 0
+        while !frontier.isEmpty, collected < maxChars, visited < visitCap {
+            let node = frontier.removeLast()
             visited += 1
-            if let v = stringValue(node), !v.isEmpty { out += v; out += "\n" }
+            if let v = stringValue(node), !v.isEmpty {
+                chunks.append(v)
+                collected += v.count + 1
+            }
             frontier.append(contentsOf: children(of: node))
         }
-        let trimmed = out.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : String(trimmed.prefix(maxChars))
+        let trimmed = chunks.reversed().joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : recentText(trimmed, maxChars: maxChars)
     }
 
     private static func role(of element: AXUIElement) -> String? {

--- a/Sources/Shadowtype/CompletionCoordinator.swift
+++ b/Sources/Shadowtype/CompletionCoordinator.swift
@@ -168,9 +168,10 @@ final class CompletionCoordinator {
 
     // Tier 2a: true while the current generation is a mid-word HEAL — the engine regenerated the typed
     // word from a clean boundary and already stripped the reproduced stem, so the ghost text is final.
-    // renderSuggestion then skips the prefix-relative transforms (reconcile leading space / glue guard /
-    // prefix-dup / language drift), which assume a fresh continuation and would mangle the healed tail
-    // ("at" → " at"). Set per generation in startGeneration. See MidWordHealing / RequiredPrefix.
+    // renderSuggestion then skips only the prefix-relative text transforms (reconcile leading space /
+    // glue guard / prefix-dup), which assume a fresh continuation and would mangle the healed tail
+    // ("at" → " at"). Language safety still applies: a healed wrong-language tail is still wrong.
+    // Set per generation in startGeneration. See MidWordHealing / RequiredPrefix.
     private var generationIsHealed = false
 
     // True while the current generation is a TERMINAL shell-command completion (the buffer was a plain
@@ -384,6 +385,9 @@ final class CompletionCoordinator {
     // The prefix side of the language-drift guard. `.none` = not computed / prefix too short or
     // ambiguous (the guard then never fires, matching languageDrifts' own conservative bail).
     private var generationPrefixLang: NLLanguage?
+    // User-declared onboarding languages latched once with the generation, so every prefix/suggestion
+    // read uses the same candidate set without hitting UserDefaults on every streamed render tick.
+    private var generationLanguageConstraints: [NLLanguage] = []
     // The ONE focus resolution for the current fire() (#9). Every gate in fire() and the render path
     // reads AX facts from here instead of re-walking the tree. Dropped in cancel(); `currentFocusSnapshot`
     // additionally refuses to hand back a snapshot whose focus session has since changed, so a stale
@@ -635,7 +639,11 @@ final class CompletionCoordinator {
         // Steer the base model to the SELECTION's language. The exemplar is English; without an explicit
         // marker the model mirrors it and emits English regardless of what the user selected. Confidence
         // threshold matches languageDrifts (0.50) — selections are user-curated, lower noise than OCR.
-        let lang = Self.dominantLanguage(selection, minConfidence: 0.50).flatMap(Self.englishLanguageName)
+        let declared = UserDefaults.standard.string(forKey: Self.personalizeLanguagesKey) ?? ""
+        let languageConstraints = Self.parsePersonalizedLanguages(declared)
+        let lang = Self.dominantLanguage(selection, minConfidence: 0.50,
+                                         languageConstraints: languageConstraints)
+            .flatMap(Self.englishLanguageName)
         let prompt = RewriteAction.prompt(for: action, selection: selection, userTone: tone, language: lang)
         let budget = RewriteAction.maxTokens(forSelection: selection)
         // Ghost sampling minus the ghost stop policy, plus a fresh seed per call so ⌘R redo actually
@@ -913,6 +921,7 @@ final class CompletionCoordinator {
         generationCaretRect = nil
         generationFont = nil
         generationPrefixLang = nil
+        generationLanguageConstraints = []
         renderSuggestion(remainder)
     }
 
@@ -982,7 +991,10 @@ final class CompletionCoordinator {
         // user is not moving. Each of these ran on EVERY ~33 ms render tick: a full
         // NLLanguageRecognizer pass over the whole prefix, plus an AX caret-rect and an AX caret-font
         // round trip per frame.
-        generationPrefixLang = Self.driftPrefixLanguage(prefix)
+        let declared = UserDefaults.standard.string(forKey: Self.personalizeLanguagesKey) ?? ""
+        generationLanguageConstraints = Self.parsePersonalizedLanguages(declared)
+        generationPrefixLang = Self.driftPrefixLanguage(
+            prefix, languageConstraints: generationLanguageConstraints)
         let caret = currentFocusSnapshot.flatMap { context.caretRectOnScreen(in: $0) }
             ?? context.caretRectOnScreen()
         generationCaretRect = caret
@@ -1541,24 +1553,15 @@ final class CompletionCoordinator {
         if prefixTransforms, Self.isPrefixDuplicate(suggestion: text, prefix: activePrefix) {
             rejectRender("prefix-duplicate"); return
         }
-        // Language-drift guard: a base model sometimes switches language mid-stream (an English ghost in a
-        // Spanish doc). Suppress only on a confident, clearly-different language read (skip on the stale
-        // remainder re-render). Conservative — never fires on a short/ambiguous prefix.
-        // #9: the prefix side of this read is hoisted to startGeneration — `activePrefix` is fixed for
-        // the whole generation, so re-running NLLanguageRecognizer over it on every streamed snapshot
-        // was pure waste. Only the (growing) suggestion is still detected per tick.
-        if prefixTransforms, Self.languageDrifts(prefixLanguage: generationPrefixLang, suggestion: text) {
-            rejectRender("lang-drift"); return
-        }
-        // Context-language guard: when the surrounding conversation has a confident dominant language,
-        // suppress a completion that drifts to a DIFFERENT language (a base model following the
-        // immediate prefix over the far-away Context: block — generic Spanish in a Catalan thread). The
-        // steer above tries to match; this hides what still drifts (user choice: match convo, else hide).
-        // Catches the short-prefix case the prefix-based languageDrifts can't, since the context read is
-        // long + high-confidence. Skipped on the stale accept-remainder re-render.
-        if prefixTransforms, let target = generationContextLang,
-           Self.suggestionConflictsWithContext(suggestion: text, contextLang: target) {
-            rejectRender("context-lang conflict"); return
+        // Language safety is skipped only on the stale accept-remainder re-render. Unlike the text
+        // transforms above, it stays active for healed generations: healing changes token alignment,
+        // not whether a confidently wrong-language completion is safe to show.
+        if let reason = Self.languageRejectionReason(
+            checkPrefixDup: checkPrefixDup, generationIsHealed: generationIsHealed,
+            prefixLanguage: generationPrefixLang, suggestion: text, contextLang: generationContextLang,
+            languageConstraints: generationLanguageConstraints
+        ) {
+            rejectRender(reason); return
         }
         }
         // Drop leading newlines (the model often "ends" the line then starts a template) and require
@@ -1719,6 +1722,7 @@ final class CompletionCoordinator {
         generationCaretRect = nil
         generationFont = nil
         generationPrefixLang = nil
+        generationLanguageConstraints = []
     }
 
     // MARK: - Host font watch (FR-OV-4)
@@ -1963,9 +1967,15 @@ final class CompletionCoordinator {
         // goes into the `Text (in <Language>):` marker sitting immediately before the prefix — a changed
         // prompt head, i.e. a full cold re-prefill, every time it flipped.
         if changed {
+            let declared = UserDefaults.standard.string(forKey: Self.personalizeLanguagesKey) ?? ""
+            let languageConstraints = Self.parsePersonalizedLanguages(declared)
             ocrCacheLang = text.map { Self.caretLocalContextTail($0) }
-                .flatMap { Self.dominantLanguage($0, minConfidence: 0.70) }
+                .flatMap {
+                    Self.dominantLanguage($0, minConfidence: 0.70,
+                                          languageConstraints: languageConstraints)
+                }
         }
+        Diag.log("context: capture steerLang=\(ocrCacheLang?.rawValue ?? "nil")")
         return changed
     }
 
@@ -2101,6 +2111,37 @@ final class CompletionCoordinator {
     // expected English form regardless of the user's UI locale. nil if the code has no known name.
     static func englishLanguageName(_ language: NLLanguage) -> String? {
         Locale(identifier: "en_US").localizedString(forLanguageCode: language.rawValue)
+    }
+
+    private static let personalizeLanguagesKey = "shadowtype.personalize.languages"
+    private static let personalizedLanguageCandidates =
+        Locale.LanguageCode.isoLanguageCodes.map { NLLanguage($0.identifier) }
+
+    // Parse onboarding's free-text language list without consulting defaults. English display names and
+    // raw ISO codes are both accepted case-insensitively; unknown entries are ignored and duplicates
+    // collapse while preserving the user's order.
+    static func parsePersonalizedLanguages(
+        _ value: String,
+        candidates: [NLLanguage] = personalizedLanguageCandidates
+    ) -> [NLLanguage] {
+        let locale = Locale(identifier: "en_US")
+        var byCode: [String: NLLanguage] = [:]
+        var byName: [String: NLLanguage] = [:]
+        for language in candidates {
+            byCode[language.rawValue.lowercased(with: locale), default: language] = language
+            if let name = englishLanguageName(language)?.lowercased(with: locale) {
+                byName[name, default: language] = language
+            }
+        }
+        var seen = Set<NLLanguage>()
+        return value.split(separator: ",").compactMap { rawToken in
+            let token = rawToken.trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased(with: locale)
+            guard let language = byCode[token] ?? byName[token], seen.insert(language).inserted else {
+                return nil
+            }
+            return language
+        }
     }
 
     // #8: global BYTE ceiling for the assembled prompt (context blocks + prefix). MIRRORED FROM the
@@ -2630,28 +2671,36 @@ final class CompletionCoordinator {
     // short text. Returns false on any ambiguity, so good completions are never collateral. Pure-ish
     // (NaturalLanguage only, no I/O) and testable.
     static func languageDrifts(prefix: String, suggestion: String,
-                               minPrefixChars: Int = 40, minConfidence: Double = 0.80) -> Bool {
+                               minPrefixChars: Int = 40, minConfidence: Double = 0.80,
+                               languageConstraints: [NLLanguage] = []) -> Bool {
         languageDrifts(prefixLanguage: driftPrefixLanguage(prefix, minPrefixChars: minPrefixChars,
-                                                           minConfidence: minConfidence),
-                       suggestion: suggestion, minConfidence: minConfidence)
+                                                           minConfidence: minConfidence,
+                                                           languageConstraints: languageConstraints),
+                       suggestion: suggestion, minConfidence: minConfidence,
+                       languageConstraints: languageConstraints)
     }
 
     // The prefix half of the drift read, split out so the caller can compute it ONCE per generation
     // instead of once per streamed render tick (#9) — `activePrefix` cannot change while the model is
     // streaming. nil = too short or not confident enough, i.e. the guard must not fire.
     static func driftPrefixLanguage(_ prefix: String,
-                                    minPrefixChars: Int = 40, minConfidence: Double = 0.80) -> NLLanguage? {
+                                    minPrefixChars: Int = 40, minConfidence: Double = 0.80,
+                                    languageConstraints: [NLLanguage] = []) -> NLLanguage? {
         let p = prefix.trimmingCharacters(in: .whitespacesAndNewlines)
         guard p.count >= minPrefixChars else { return nil }
-        return dominantLanguage(p, minConfidence: minConfidence)
+        return dominantLanguage(p, minConfidence: minConfidence,
+                                languageConstraints: languageConstraints)
     }
 
     // The per-tick half: only the (growing) suggestion is re-read.
     static func languageDrifts(prefixLanguage: NLLanguage?, suggestion: String,
-                               minConfidence: Double = 0.80) -> Bool {
+                               minConfidence: Double = 0.80,
+                               languageConstraints: [NLLanguage] = []) -> Bool {
         guard let pl = prefixLanguage else { return false }
         let s = suggestion.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard s.count >= 4, let sl = dominantLanguage(s, minConfidence: minConfidence) else { return false }
+        guard s.count >= 4,
+              let sl = dominantLanguage(s, minConfidence: minConfidence,
+                                        languageConstraints: languageConstraints) else { return false }
         return pl != sl
     }
 
@@ -2663,14 +2712,37 @@ final class CompletionCoordinator {
     // (NaturalLanguage only) and testable.
     static func suggestionConflictsWithContext(suggestion: String, contextLang: NLLanguage,
                                                minSuggestionChars: Int = 8,
-                                               minConfidence: Double = 0.80) -> Bool {
+                                               minConfidence: Double = 0.80,
+                                               languageConstraints: [NLLanguage] = []) -> Bool {
         let s = suggestion.trimmingCharacters(in: .whitespacesAndNewlines)
         guard s.count >= minSuggestionChars,
-              let sl = dominantLanguage(s, minConfidence: minConfidence) else { return false }
+              let sl = dominantLanguage(s, minConfidence: minConfidence,
+                                        languageConstraints: languageConstraints) else { return false }
         return sl != contextLang
     }
 
-    // Best-guess language of `text`, but only when the top hypothesis clears `minConfidence`; else nil.
+    // Pure render policy for the two language backstops. `generationIsHealed` is deliberately not a
+    // gate: healing only exempts prefix-relative text transforms. `checkPrefixDup == false` identifies
+    // the stale accept-remainder re-render, where both language comparisons must stay skipped.
+    static func languageRejectionReason(checkPrefixDup: Bool, generationIsHealed _: Bool,
+                                        prefixLanguage: NLLanguage?, suggestion: String,
+                                        contextLang: NLLanguage?,
+                                        languageConstraints: [NLLanguage] = []) -> String? {
+        guard checkPrefixDup else { return nil }
+        if languageDrifts(prefixLanguage: prefixLanguage, suggestion: suggestion,
+                          languageConstraints: languageConstraints) {
+            return "lang-drift"
+        }
+        if let contextLang,
+           suggestionConflictsWithContext(suggestion: suggestion, contextLang: contextLang,
+                                          languageConstraints: languageConstraints) {
+            return "context-lang conflict"
+        }
+        return nil
+    }
+
+    // Best-guess language of `text`, but only when the top hypothesis clears `minConfidence` and leads
+    // the runner-up by a safe margin; else nil.
     // The de-chromed context nearest the caret (last few non-empty lines), for LANGUAGE detection only.
     // A full-screen OCR capture is mostly far-away UI chrome whose language (usually English) drowns out
     // the conversation; the recent messages at the tail are the reply language. Pure + testable.
@@ -2680,11 +2752,35 @@ final class CompletionCoordinator {
         return tail.count <= maxChars ? tail : String(tail.suffix(maxChars))
     }
 
-    private static func dominantLanguage(_ text: String, minConfidence: Double) -> NLLanguage? {
+    // The declared languages are a TIE-BREAK, never a filter. Reading unconstrained first is what keeps
+    // a language the user never declared detectable: measured, an undeclared German sentence scores
+    // de:1.00 open but en:0.71 when constrained to {en,es,ca} — confident enough to clear both gates
+    // below and steer a German thread into English. So the open read always wins when it is confident.
+    static func dominantLanguage(_ text: String, minConfidence: Double,
+                                 languageConstraints: [NLLanguage] = []) -> NLLanguage? {
+        if let open = confidentLanguage(text, minConfidence: minConfidence, constraints: []) {
+            return open
+        }
+        // Only where the open read was NOT confident do the declared languages get to disambiguate.
+        // Apple scores close Romance pairs flat on short text ("la solucio jo la tiraria mes per alla"
+        // reads ca:0.76/it:0.19 open, ca:0.94/es:0.06 constrained), which is the case this exists for.
+        // This can never invent a language: it only picks among the ones the user says they write in,
+        // and only where the unconstrained read would have returned nil.
+        guard !languageConstraints.isEmpty else { return nil }
+        return confidentLanguage(text, minConfidence: minConfidence, constraints: languageConstraints)
+    }
+
+    private static func confidentLanguage(_ text: String, minConfidence: Double,
+                                          constraints: [NLLanguage]) -> NLLanguage? {
         let recognizer = NLLanguageRecognizer()
+        if !constraints.isEmpty { recognizer.languageConstraints = constraints }
         recognizer.processString(text)
-        guard let top = recognizer.languageHypotheses(withMaximum: 1).max(by: { $0.value < $1.value }),
-              top.value >= minConfidence else { return nil }
+        let hypotheses = recognizer.languageHypotheses(withMaximum: 2)
+            .sorted { $0.value > $1.value }
+        guard let top = hypotheses.first, top.value >= minConfidence else { return nil }
+        // A ten-point lead is conservative enough to keep clear prose while refusing mixed blobs where
+        // Apple's close Romance-language scores make a single winner look more certain than it is.
+        if hypotheses.count > 1, top.value - hypotheses[1].value < 0.10 { return nil }
         return top.key
     }
 
@@ -2756,7 +2852,11 @@ final class CompletionCoordinator {
     private func computeSpuriousGlue(suggestion: String, prefix: String) -> String? {
         // Lenient language read (looser than the 40-char/0.80 drift gate) so short prefixes can resolve, but
         // keep a small floor — NLLanguageRecognizer is noise on a handful of chars. Below it, bail (keep).
-        guard prefix.count >= 12, let lang = Self.dominantLanguage(prefix, minConfidence: 0.50) else {
+        guard prefix.count >= 12,
+              let lang = Self.dominantLanguage(
+                prefix, minConfidence: 0.50,
+                languageConstraints: generationLanguageConstraints
+              ) else {
             return nil
         }
         let checker = NSSpellChecker.shared

--- a/Sources/Shadowtype/EditContextTracker.swift
+++ b/Sources/Shadowtype/EditContextTracker.swift
@@ -696,15 +696,39 @@ final class EditContextTracker {
     // holds the conversation) and reads its full text. nil for native apps / no web area / secure
     // fields — the caller then falls back to OCR. Best-effort: never throws, never returns wrong text.
     func pageContextText() -> String? {
-        guard let element = currentFocusedElement(), !isSecure(element),
-              let webArea = AXTextProbe.topWebArea(from: element) else { return nil }
-        return AXTextProbe.webAreaFullText(of: webArea)
+        guard let element = currentFocusedElement(), !isSecure(element) else {
+            return pageContextText(from: nil)
+        }
+        return pageContextText(from: AXTextProbe.topWebArea(from: element))
     }
 
     /// Same text from a snapshot, reusing the web area it already walked up to.
     func pageContextText(in snapshot: FocusSnapshot) -> String? {
-        guard !snapshot.isSecure, let webArea = snapshot.webArea else { return nil }
-        return AXTextProbe.webAreaFullText(of: webArea)
+        pageContextText(from: snapshot.isSecure ? nil : snapshot.webArea)
+    }
+
+    private func pageContextText(from webArea: AXUIElement?) -> String? {
+        guard let webArea else {
+            return Self.loggedPageContextText(webAreaFound: false, text: nil, log: Diag.log)
+        }
+        return Self.loggedPageContextText(
+            webAreaFound: true,
+            text: AXTextProbe.webAreaFullText(of: webArea),
+            log: Diag.log)
+    }
+
+    static func loggedPageContextText(webAreaFound: Bool, text: String?,
+                                      log: (String) -> Void) -> String? {
+        guard webAreaFound else {
+            log("pagectx: no web area")
+            return nil
+        }
+        guard let text, !text.isEmpty else {
+            log("pagectx: web area empty")
+            return nil
+        }
+        log("pagectx: ok chars=\(text.count)")
+        return text
     }
 
     // True when the focused field is STRUCTURED input (a search box, or a browser's address/omnibox /

--- a/Sources/Shadowtype/ScreenContextProvider.swift
+++ b/Sources/Shadowtype/ScreenContextProvider.swift
@@ -34,10 +34,11 @@ final class ScreenContextProvider {
         guard #available(macOS 14.0, *) else { return nil }
 
         guard let image = await captureFocusedWindow() else {
-            return Self.clamp(currentCachedText(), to: maxChars)
+            return nil
         }
         guard let text = await Self.recognizeText(in: image) else {
-            return Self.clamp(currentCachedText(), to: maxChars)
+            Diag.log("ocr: capture yielded no text")
+            return nil
         }
 
         // Drop obvious UI chrome (buttons, prices, chips) BEFORE clamp so the budget + tail go to real
@@ -59,11 +60,6 @@ final class ScreenContextProvider {
         return (true, nil)
     }
 
-    private func currentCachedText() -> String? {
-        stateLock.lock(); defer { stateLock.unlock() }
-        return cachedText
-    }
-
     private func storeCachedText(_ text: String) {
         stateLock.lock(); defer { stateLock.unlock() }
         cachedText = text
@@ -71,7 +67,7 @@ final class ScreenContextProvider {
 
     // MARK: Capture
 
-    // Picks the frontmost app's frontmost on-screen window and captures just that window's bounds.
+    // Picks the frontmost app's largest normal-level on-screen window and captures its bounds.
     // Tight crop matters: OCR latency is dominated by region size (per FR-CTX-1).
     private func captureFocusedWindow() async -> CGImage? {
         do {
@@ -92,8 +88,10 @@ final class ScreenContextProvider {
             config.ignoreShadowsSingleWindow = true
             config.scalesToFit = true
 
-            return try await SCScreenshotManager.captureImage(
+            let image = try await SCScreenshotManager.captureImage(
                 contentFilter: filter, configuration: config)
+            Diag.log("ocr: capture window=\(Int(window.frame.width))x\(Int(window.frame.height))pt image=\(image.width)x\(image.height)px")
+            return image
         } catch {
             // Screen Recording permission missing, window gone, etc. -> degrade to nil.
             Diag.log("ocr: capture FAILED \(error)")
@@ -101,8 +99,8 @@ final class ScreenContextProvider {
         }
     }
 
-    // Best-effort "focused window": the frontmost regular app's frontmost window. Falls back to the
-    // first on-screen window owned by the frontmost app. nil if nothing matches.
+    // Best-effort focused document window: the frontmost regular app's largest layer-0 window.
+    // Falls back to its largest on-screen window when no normal-level window exists.
     private func focusedWindow(in windows: [SCWindow]) -> SCWindow? {
         let frontPid = NSWorkspace.shared.frontmostApplication?.processIdentifier
         let candidates = windows.filter { win in
@@ -112,13 +110,19 @@ final class ScreenContextProvider {
             }
             return false
         }
-        // Higher windowLayer == frontmost; prefer the largest among the topmost layer.
-        return candidates
-            .sorted { lhs, rhs in
-                if lhs.windowLayer != rhs.windowLayer { return lhs.windowLayer > rhs.windowLayer }
-                return (lhs.frame.width * lhs.frame.height) > (rhs.frame.width * rhs.frame.height)
-            }
-            .first
+        // Layer 0 holds the document window; higher layers can be floating chrome strips or HUDs.
+        // Prefer the largest normal window, falling back to the largest candidate only when needed.
+        let choices = candidates.map {
+            (layer: $0.windowLayer, area: Double($0.frame.width * $0.frame.height))
+        }
+        guard let index = Self.preferredWindowIndex(in: choices) else { return nil }
+        return candidates[index]
+    }
+
+    static func preferredWindowIndex(in candidates: [(layer: Int, area: Double)]) -> Int? {
+        let normal = candidates.indices.filter { candidates[$0].layer == 0 }
+        let eligible = normal.isEmpty ? Array(candidates.indices) : normal
+        return eligible.max { candidates[$0].area < candidates[$1].area }
     }
 
     private static func pointScale(for window: SCWindow) -> CGFloat {

--- a/Tests/ShadowtypeTests/CaretLineEndTests.swift
+++ b/Tests/ShadowtypeTests/CaretLineEndTests.swift
@@ -59,4 +59,9 @@ final class LineRemainderClassifyTests: XCTestCase {
         XCTAssertEqual(AXTextProbe.classifyLineRemainder(" x"), .midLine)
         XCTAssertEqual(AXTextProbe.classifyLineRemainder("\tx"), .midLine)
     }
+
+    func testPageContextCapKeepsComposerAdjacentTail() {
+        let page = "oldest-message\nolder-message\nResponder en español"
+        XCTAssertEqual(AXTextProbe.recentText(page, maxChars: 20), "Responder en español")
+    }
 }

--- a/Tests/ShadowtypeTests/CompletionLanguageGuardTests.swift
+++ b/Tests/ShadowtypeTests/CompletionLanguageGuardTests.swift
@@ -1,0 +1,120 @@
+import NaturalLanguage
+import XCTest
+@testable import Shadowtype
+
+final class CompletionLanguageGuardTests: XCTestCase {
+    func testHealedGenerationStillSuppressesWrongLanguage() {
+        let prefixReason = CompletionCoordinator.languageRejectionReason(
+            checkPrefixDup: true,
+            generationIsHealed: true,
+            prefixLanguage: .catalan,
+            suggestion: "I know that my team can finish the project tomorrow morning",
+            contextLang: .catalan
+        )
+        let contextReason = CompletionCoordinator.languageRejectionReason(
+            checkPrefixDup: true,
+            generationIsHealed: true,
+            prefixLanguage: nil,
+            suggestion: "I know that my team can finish the project tomorrow morning",
+            contextLang: .catalan
+        )
+        let staleRemainderReason = CompletionCoordinator.languageRejectionReason(
+            checkPrefixDup: false,
+            generationIsHealed: true,
+            prefixLanguage: .catalan,
+            suggestion: "I know that my team can finish the project tomorrow morning",
+            contextLang: .catalan
+        )
+
+        XCTAssertEqual(prefixReason, "lang-drift")
+        XCTAssertEqual(contextReason, "context-lang conflict")
+        XCTAssertNil(staleRemainderReason)
+    }
+
+    func testPersonalizedLanguagesParseSloppyNamesAndISOCodes() {
+        let named = CompletionCoordinator.parsePersonalizedLanguages(
+            "English, Spanish, catalan")
+        let coded = CompletionCoordinator.parsePersonalizedLanguages("ca, es")
+
+        XCTAssertEqual(Set(named), Set([.english, .spanish, .catalan]))
+        XCTAssertEqual(coded, [.catalan, .spanish])
+    }
+
+    func testEmptyAndGarbagePersonalizedLanguagesPreserveUnconstrainedDetection() {
+        XCTAssertTrue(CompletionCoordinator.parsePersonalizedLanguages("").isEmpty)
+        XCTAssertTrue(CompletionCoordinator.parsePersonalizedLanguages("asdf, ???").isEmpty)
+
+        let clearEnglish = "This is a clearly written English sentence about the project schedule."
+        XCTAssertEqual(
+            CompletionCoordinator.dominantLanguage(clearEnglish, minConfidence: 0.50),
+            CompletionCoordinator.dominantLanguage(
+                clearEnglish, minConfidence: 0.50, languageConstraints: [])
+        )
+        XCTAssertEqual(
+            CompletionCoordinator.dominantLanguage(clearEnglish, minConfidence: 0.50),
+            .english
+        )
+    }
+
+    func testDeclaredLanguagesConstrainCatalanDetection() {
+        let text = "Aquesta conversa parla de la feina i de tot el que hem de preparar demà."
+
+        XCTAssertEqual(
+            CompletionCoordinator.dominantLanguage(
+                text, minConfidence: 0.50,
+                languageConstraints: [.english, .spanish, .catalan]
+            ),
+            .catalan
+        )
+    }
+
+    // The declared list must not become a filter. Constraining the recognizer up front scores this
+    // German sentence en:0.71 (vs de:1.00 unconstrained) — confident enough to clear both the 0.70
+    // floor and the 0.10 margin, which would steer a German thread into English and suppress a correct
+    // German ghost. Threads here really do carry undeclared languages: the report that prompted this
+    // work had a German guest message on screen.
+    func testUndeclaredLanguageStillDetectedDespiteDeclaredList() {
+        let german = "Ich komme eigentlich erst um 1 Uhr in Malaga an, die Uhrzeit kann man nicht aussuchen"
+        XCTAssertEqual(
+            CompletionCoordinator.dominantLanguage(
+                german, minConfidence: 0.70,
+                languageConstraints: [.english, .spanish, .catalan]
+            ),
+            .german
+        )
+    }
+
+    // The flip side: where the OPEN read is too ambiguous to clear the bar, the declared languages are
+    // allowed to break the tie. This short Catalan line reads ca:0.76/it:0.19 unconstrained — under the
+    // 0.80 the drift guard uses — and ca:0.94 once narrowed to what the user says they write in.
+    func testDeclaredLanguagesBreakTieOnlyWhenOpenReadIsAmbiguous() {
+        let shortCatalan = "la solucio jo la tiraria mes per alla"
+        XCTAssertNil(
+            CompletionCoordinator.dominantLanguage(shortCatalan, minConfidence: 0.80))
+        XCTAssertEqual(
+            CompletionCoordinator.dominantLanguage(
+                shortCatalan, minConfidence: 0.80,
+                languageConstraints: [.english, .spanish, .catalan]
+            ),
+            .catalan
+        )
+    }
+
+    func testMixedLanguageBlobFailsCloseHypothesisMargin() {
+        let mixed = "This message is about work. Podemos empezar mañana."
+        let recognizer = NLLanguageRecognizer()
+        recognizer.languageConstraints = [.english, .spanish]
+        recognizer.processString(mixed)
+        let hypotheses = recognizer.languageHypotheses(withMaximum: 2)
+            .sorted { $0.value > $1.value }
+
+        XCTAssertEqual(hypotheses.count, 2)
+        XCTAssertLessThan(hypotheses[0].value - hypotheses[1].value, 0.10)
+        XCTAssertNil(
+            CompletionCoordinator.dominantLanguage(
+                mixed, minConfidence: 0.40,
+                languageConstraints: [.english, .spanish]
+            )
+        )
+    }
+}

--- a/Tests/ShadowtypeTests/M1CaptureTests.swift
+++ b/Tests/ShadowtypeTests/M1CaptureTests.swift
@@ -101,6 +101,26 @@ final class M1CaptureTests: XCTestCase {
         XCTAssertNil(tracker.focusedElement(), "no focused field / untrusted -> nil, no crash")
     }
 
+    func testPageContextLoggingReportsOutcomesWithoutContent() {
+        var logs: [String] = []
+        let log: (String) -> Void = { logs.append($0) }
+
+        XCTAssertNil(EditContextTracker.loggedPageContextText(
+            webAreaFound: false, text: nil, log: log))
+        XCTAssertNil(EditContextTracker.loggedPageContextText(
+            webAreaFound: true, text: "", log: log))
+        let pageText = "private page payload"
+        XCTAssertEqual(EditContextTracker.loggedPageContextText(
+            webAreaFound: true, text: pageText, log: log), pageText)
+
+        XCTAssertEqual(logs, [
+            "pagectx: no web area",
+            "pagectx: web area empty",
+            "pagectx: ok chars=20",
+        ])
+        XCTAssertFalse(logs.joined().contains(pageText))
+    }
+
     // Injector with a nil element falls back to the Unicode path and reports placement (FR-IN-3).
     // Empty text is a no-op success. Neither requires AX writes, so both are CI-safe.
     func testInjectorEmptyTextIsNoOpSuccess() {

--- a/Tests/ShadowtypeTests/OCRCleanupTests.swift
+++ b/Tests/ShadowtypeTests/OCRCleanupTests.swift
@@ -1,11 +1,25 @@
-// OCRCleanupTests — pure-function coverage for the FR-CTX-1 screen-OCR cleanup helpers that feed the
-// completion prompt: denoise (chrome filtering) and removingDraftEcho (de-duplicating the user's own
-// draft). No ScreenCaptureKit / Vision needed — runs under `swift test`.
+// OCRCleanupTests — pure-function coverage for the FR-CTX-1 screen-OCR selection and cleanup helpers
+// that feed the completion prompt. No ScreenCaptureKit / Vision needed — runs under `swift test`.
 import XCTest
 import NaturalLanguage
 @testable import Shadowtype
 
 final class OCRCleanupTests: XCTestCase {
+
+    // MARK: - focused window selection
+
+    func testFocusedWindowPrefersLargestNormalWindowOverElectronChrome() {
+        let candidates: [(layer: Int, area: Double)] = [
+            (layer: 26, area: 1512 * 33),
+            (layer: 0, area: 1512 * 32),
+            (layer: 0, area: 1512 * 949),
+        ]
+
+        XCTAssertEqual(ScreenContextProvider.preferredWindowIndex(in: candidates), 2)
+
+        let floatingOnly = [(layer: 26, area: 100.0), (layer: 8, area: 200.0)]
+        XCTAssertEqual(ScreenContextProvider.preferredWindowIndex(in: floatingOnly), 1)
+    }
 
     // MARK: - denoise
 


### PR DESCRIPTION
Screen context was feeding the model a nine-minute-old snapshot of a **different application**. Typing a reply in a Catalan Slack thread produced a fluent English ghost, because the prompt's context block held a stale capture of an English code editor — so the steer marker said `Text (in English):` and the model wrote English on purpose.

Root-caused from the reporter's own diag log, not from the screenshot.

## The chain

```
11:28:00.174 ocr: vision observations=0 chars=0     ← this capture saw nothing
11:28:00.196 ocr: refresh got 967 chars changed=true ← 967 chars came from cache
11:28:00.201 fire: START gen len=7                   ← "perfect"
11:28:00.473 gen: done len=19                        ← "ly. I know that my"
```

**1. `focusedWindow` captured the wrong window.** It sorted by `windowLayer` descending on the belief that higher layer = frontmost. Layer 0 is where document windows live; higher layers hold floating chrome. Enumerating live windows:

```
layer=  26   1512x33    ← picked by the old sort
layer=   0   1512x949   ← the actual window
```

Vision OCR'd a 33-pixel sliver. **71 of 72 captures in the reported session returned zero observations.** The single success was a native app with no high-layer window.

**2. Failure served poisoned cache.** Both failure branches of `recentText` fell back to `cachedText` — process-global, no app identity, no age limit. `storeCachedText` also runs *before* the coordinator's focus-change guard, so the one successful capture was rejected as stale for its own app and then handed to three unrelated apps over the next nine minutes.

Bug 1 alone degrades to no context. Bug 1 + bug 2 is what produced a confident English sentence in a Catalan thread.

## Also fixed, found tracing the same path

- **The language backstops were switched off by mid-word healing.** Both hung off `prefixTransforms` = `checkPrefixDup && !generationIsHealed`. That flag protects a healed tail from the glue/leading-space transforms; the rationale doesn't extend to language safety. Typing `perfect` triggers healing, so the guard written for exactly this failure was disabled.
- **`webAreaFullText` head-truncated**, keeping the oldest 20k of a thread and dropping the messages nearest the composer — the ones carrying the reply language.
- **The onboarding language list is finally wired up.** `personalize.languages` only ever became a prose sentence in the instruction block. It now disambiguates the recognizer — as a **tie-break, not a filter**. Constraining up front measured *worse*: undeclared German scores `de:1.00` open but `en:0.71` constrained to `{en,es,ca}`, clearing both the 0.70 floor and the 0.10 margin. The open read wins whenever confident; the declared list only runs where the open read would have returned nil.
- **Diagnostics** for capture dimensions, detected steer language, and which step of the AX page-context path failed. The absence of all three is why this read as a language-detection bug.

## Verification

715 tests, 2 skipped, 0 failures (baseline 705). New coverage pins the real observed window list, healed-generation language suppression, undeclared-German detection, and the Catalan tie-break.

Not attempted here: Slack-specific AX thread extraction — the new `pagectx:` logging should say *why* that path is silent before designing around a guess. The capture throttle can also still serve app A's text to app B during a fast switch; a much smaller version of the same flaw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)